### PR TITLE
Add code to support do-not-disturb on GNOME

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "electron-store": "^2.0.0",
     "electron-window-state": "^4.1.0",
     "minimist": "^1.2.3",
-    "png-to-ico": "^1.0.2"
+    "png-to-ico": "^1.0.2",
+    "dbus-next": "^0.8.2"
   },
   "devDependencies": {
     "asar": "^2.0.1",

--- a/src/do-not-disturb.js
+++ b/src/do-not-disturb.js
@@ -1,0 +1,51 @@
+
+// Always false if the platform doesn't support it.
+global.isDoNotDisturb = false;
+
+function init() {
+    if (process.platform === "linux") {
+        return initForLinux();
+    }
+}
+
+async function initForLinux() {
+    // TODO: This is specific to the GNOME desktop implementation of DND
+
+    const DBus = require('dbus-next');
+    const child_process = require('child_process');
+    // First we need to determine the value of dnd.
+    try {
+        // XXX: After much flailing about, I couldn't find another acceptable way to fetch this setting value.
+        const value = child_process.execSync("gsettings get org.gnome.desktop.notifications show-banners", { encoding: "utf-8"}).trim();
+        if (value) {
+            // Anything other than true will be safely false.
+            // Invert because show-banners === do-disturb :)
+            global.isDoNotDisturb = !Boolean(value === 'true');
+            console.log(`do-not-disturb value has been detected as: ${global.isDoNotDisturb}`);
+        }
+    } catch (ex) {
+        console.warn("Could not execute gsettings command to determine do-not-disturb value. Functionality disabled");
+        console.debug(ex.message);
+        return;
+    }
+
+
+    const session = DBus.sessionBus();
+    process.on("exit", () => {
+        session.disconnect();
+    });
+    let obj = await session.getProxyObject('ca.desrt.dconf', '/ca/desrt/dconf/Writer/user');
+    let signaller = obj.getInterface('ca.desrt.dconf.Writer');
+    signaller.on('Notify', (settingName) => {
+        if (settingName == '/org/gnome/desktop/notifications/show-banners') {
+            // The D-BUS signal will only tell you that the setting changed, but annoyingly
+            // not the value. Since we got the value on startup, assume it's just been toggled.
+            global.isDoNotDisturb = !global.isDoNotDisturb;
+            console.log(`do-not-disturb value has been detected as: ${global.isDoNotDisturb}`);
+        }
+    });
+}
+
+module.exports = {
+    init,
+}

--- a/src/do-not-disturb.js
+++ b/src/do-not-disturb.js
@@ -2,6 +2,8 @@
 // Always false if the platform doesn't support it.
 global.isDoNotDisturb = false;
 
+const LINUX_SETTING_COMMAND = "gsettings get org.gnome.desktop.notifications show-banners";
+
 function init() {
     if (process.platform === "linux") {
         return initForLinux();
@@ -12,15 +14,15 @@ async function initForLinux() {
     // TODO: This is specific to the GNOME desktop implementation of DND
 
     const DBus = require('dbus-next');
-    const child_process = require('child_process');
+    const { execSync } = require('child_process');
     // First we need to determine the value of dnd.
     try {
         // XXX: After much flailing about, I couldn't find another acceptable way to fetch this setting value.
-        const value = child_process.execSync("gsettings get org.gnome.desktop.notifications show-banners", { encoding: "utf-8"}).trim();
+        const value = execSync(LINUX_SETTING_COMMAND, { encoding: "utf-8" }).trim();
         if (value) {
             // Anything other than true will be safely false.
             // Invert because show-banners === do-disturb :)
-            global.isDoNotDisturb = !Boolean(value === 'true');
+            global.isDoNotDisturb = value !== 'true';
             console.log(`do-not-disturb value has been detected as: ${global.isDoNotDisturb}`);
         }
     } catch (ex) {
@@ -34,8 +36,8 @@ async function initForLinux() {
     process.on("exit", () => {
         session.disconnect();
     });
-    let obj = await session.getProxyObject('ca.desrt.dconf', '/ca/desrt/dconf/Writer/user');
-    let signaller = obj.getInterface('ca.desrt.dconf.Writer');
+    const obj = await session.getProxyObject('ca.desrt.dconf', '/ca/desrt/dconf/Writer/user');
+    const signaller = obj.getInterface('ca.desrt.dconf.Writer');
     signaller.on('Notify', (settingName) => {
         if (settingName == '/org/gnome/desktop/notifications/show-banners') {
             // The D-BUS signal will only tell you that the setting changed, but annoyingly
@@ -48,4 +50,4 @@ async function initForLinux() {
 
 module.exports = {
     init,
-}
+};

--- a/src/do-not-disturb.js
+++ b/src/do-not-disturb.js
@@ -1,8 +1,11 @@
-
 // Always false if the platform doesn't support it.
-global.isDoNotDisturb = false;
-
 const LINUX_SETTING_COMMAND = "gsettings get org.gnome.desktop.notifications show-banners";
+
+const { promisify } = require('util');
+const childProcess = require('child_process');
+const exec = promisify(childProcess.exec);
+
+let doNotDisturbMode = false;
 
 function init() {
     if (process.platform === "linux") {
@@ -10,20 +13,23 @@ function init() {
     }
 }
 
-async function initForLinux() {
-    // TODO: This is specific to the GNOME desktop implementation of DND
+function isDoNotDisturb() {
+    return doNotDisturbMode;
+}
 
+async function initForLinux() {
     const DBus = require('dbus-next');
-    const { execSync } = require('child_process');
+    // This is specific to the GNOME implementation for do-not-distrub
+
     // First we need to determine the value of dnd.
     try {
         // XXX: After much flailing about, I couldn't find another acceptable way to fetch this setting value.
-        const value = execSync(LINUX_SETTING_COMMAND, { encoding: "utf-8" }).trim();
+        const value = (await exec(LINUX_SETTING_COMMAND, { encoding: "utf-8" })).trim();
         if (value) {
             // Anything other than true will be safely false.
             // Invert because show-banners === do-disturb :)
-            global.isDoNotDisturb = value !== 'true';
-            console.log(`do-not-disturb value has been detected as: ${global.isDoNotDisturb}`);
+            doNotDisturbMode = value !== 'true';
+            console.log(`do-not-disturb value has been detected as: ${doNotDisturbMode}`);
         }
     } catch (ex) {
         console.warn("Could not execute gsettings command to determine do-not-disturb value. Functionality disabled");
@@ -33,16 +39,14 @@ async function initForLinux() {
 
 
     const session = DBus.sessionBus();
-    process.on("exit", () => {
-        session.disconnect();
-    });
+    process.on("exit", () => session.disconnect());
     const obj = await session.getProxyObject('ca.desrt.dconf', '/ca/desrt/dconf/Writer/user');
     const signaller = obj.getInterface('ca.desrt.dconf.Writer');
     signaller.on('Notify', (settingName) => {
         if (settingName == '/org/gnome/desktop/notifications/show-banners') {
             // The D-BUS signal will only tell you that the setting changed, but annoyingly
             // not the value. Since we got the value on startup, assume it's just been toggled.
-            global.isDoNotDisturb = !global.isDoNotDisturb;
+            doNotDisturbMode = !doNotDisturbMode;
             console.log(`do-not-disturb value has been detected as: ${global.isDoNotDisturb}`);
         }
     });
@@ -50,4 +54,5 @@ async function initForLinux() {
 
 module.exports = {
     init,
+    isDoNotDisturb,
 };

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -352,8 +352,8 @@ ipcMain.on('ipcCall', async function(ev, payload) {
             global.mainWindow.autoHideMenuBar = Boolean(args[0]);
             global.mainWindow.setMenuBarVisibility(!args[0]);
             break;
-        case 'getMaySendNotifications':
-            ret = !global.isDoNotDisturb;
+        case 'getDoNotDisturbEnabled':
+            ret = doNotDisturb.isDoNotDisturb();
             break;
         case 'getAppVersion':
             ret = app.getVersion();

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -47,6 +47,7 @@ const fs = require('fs');
 const afs = fs.promises;
 
 const crypto = require('crypto');
+
 let keytar;
 try {
     keytar = require('keytar');
@@ -350,6 +351,9 @@ ipcMain.on('ipcCall', async function(ev, payload) {
             store.set('autoHideMenuBar', args[0]);
             global.mainWindow.autoHideMenuBar = Boolean(args[0]);
             global.mainWindow.setMenuBarVisibility(!args[0]);
+            break;
+        case 'getMaySendNotifications':
+            ret = !global.isDoNotDisturb;
             break;
         case 'getAppVersion':
             ret = app.getVersion();

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -41,6 +41,8 @@ const {getProfileFromDeeplink, protocolInit, recordSSOSession} = require('./prot
 const windowStateKeeper = require('electron-window-state');
 const Store = require('electron-store');
 
+const doNotDisturb = require('./do-not-disturb');
+
 const fs = require('fs');
 const afs = fs.promises;
 
@@ -767,6 +769,7 @@ app.on('ready', async () => {
     try {
         await setupGlobals();
         await moveAutoLauncher();
+        await doNotDisturb.init();
     } catch (e) {
         console.log("App setup failed: exiting", e);
         process.exit(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,11 @@
     update-notifier "^2.2.0"
     yargs "^8.0.2"
 
+"@nornagon/put@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@nornagon/put/-/put-0.0.8.tgz#9d497ec46c9364acc3f8b59aa3cf8ee4134ae337"
+  integrity sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -274,6 +279,14 @@ abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abstract-socket@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/abstract-socket/-/abstract-socket-2.1.1.tgz#243a7e6e6ff65bb9eab16a22fa90699b91e528f7"
+  integrity sha512-YZJizsvS1aBua5Gd01woe4zuyYBGgSMeqDOB6/ChwdTI904KP6QGtJswXl4hcqWxbz86hQBe++HWV0hF1aGUtA==
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.12.1"
 
 acorn-jsx@^5.2.0:
   version "5.2.0"
@@ -663,6 +676,13 @@ bin-links@^1.1.2, bin-links@^1.1.7:
     graceful-fs "^4.1.15"
     npm-normalize-package-bin "^1.0.0"
     write-file-atomic "^2.3.0"
+
+bindings@^1.2.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 bl@^4.0.1:
   version "4.0.2"
@@ -1244,6 +1264,28 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+dbus-next@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/dbus-next/-/dbus-next-0.8.2.tgz#b53beec47812e643d4c24a96f7ce223c32aa2edb"
+  integrity sha512-E2wkbhZzzsgmY+jxIdeuhA1nVT697I5koRIRJTk3doTeukwtzqSFG89RC5XK8OsLG/eHDZ8PVNptUuEPkhdPbA==
+  dependencies:
+    "@nornagon/put" "0.0.8"
+    event-stream "3.3.4"
+    hexy "^0.2.10"
+    jsbi "^2.0.5"
+    long "^4.0.0"
+    safe-buffer "^5.1.1"
+    xml2js "^0.4.17"
+  optionalDependencies:
+    abstract-socket "^2.0.0"
+
+dbus@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/dbus/-/dbus-1.0.7.tgz#8ec719b0943f1e77deab2d13ce74a6e5e9839e83"
+  integrity sha512-qba6/ajLoqzCy3Kl3aFgLXLP4TTf0qfgNjib1qoCJG/8HbSs0lDvxkz4nJU63CURZVzxvpK/VpQpT40KA8Kr3A==
+  dependencies:
+    nan "^2.14.0"
+
 debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -1447,6 +1489,11 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
+
+duplexer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
@@ -1997,6 +2044,19 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-stream@3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -2096,6 +2156,11 @@ file-type@^3.1.0:
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
   integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filelist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.1.tgz#f10d1a3ae86c1694808e8f20906f43d4c9132dbb"
@@ -2181,6 +2246,11 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+  integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -2467,6 +2537,11 @@ has@^1.0.1, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hexy@^0.2.10:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/hexy/-/hexy-0.2.11.tgz#9939c25cb6f86a91302f22b8a8a72573518e25b4"
+  integrity sha512-ciq6hFsSG/Bpt2DmrZJtv+56zpPdnq+NQ4ijEFrveKN0ZG1mhl/LdT1NQZ9se6ty1fACcI4d4vYqC9v8EYpH2A==
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   version "2.8.5"
@@ -2938,6 +3013,11 @@ js-yaml@^3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbi@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-2.0.5.tgz#82589011da87dc59b4b549d94dcef51a9155f6fe"
+  integrity sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ==
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -3371,6 +3451,11 @@ lodash@^4.17.15, lodash@^4.17.16, lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -3440,6 +3525,11 @@ map-age-cleaner@^0.1.1:
   integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
   dependencies:
     p-defer "^1.0.0"
+
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
 
 meant@~1.0.1:
   version "1.0.1"
@@ -3619,6 +3709,11 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nan@^2.12.1, nan@^2.14.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4371,6 +4466,13 @@ path-type@^2.0.0:
   integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
   dependencies:
     pify "^2.0.0"
+
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
+  dependencies:
+    through "~2.3"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -5132,6 +5234,13 @@ split-on-first@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -5163,6 +5272,13 @@ stat-mode@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-1.0.0.tgz#68b55cb61ea639ff57136f36b216a291800d1465"
   integrity sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-each@^1.1.0:
   version "1.2.3"
@@ -5446,7 +5562,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-"through@>=2.2.7 <3", through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -5924,6 +6040,14 @@ xml-parse-from-string@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
   integrity sha1-qQKekp09vN7RafPG4oI42VpdWig=
+
+xml2js@^0.4.17:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
 
 xml2js@^0.4.5:
   version "0.4.22"


### PR DESCRIPTION
Part of my attempt to fix the Linux side of https://github.com/vector-im/element-web/issues/7758

Caveats:
- This only helps you if you are on Linux.
- This only helps you if you are on GNOME.
- If you are not on GNOME, existing functionality (DND: false) is preserved.
- I doubt putting `dbus-next` into the dependency list is going to fly, some help there so I can get it right would be good.

This change hooks into D-BUS to listen for changes to the do not disturb state on linux. Sadly, it was a major pain in the backside to get the current *value* of the do not disturb state, so I've taken to calling `gsettings` once to determine the state, and the flipflop the value based on whether D-Bus sends us a signal. It should be robust enough to work.

Requires: https://github.com/vector-im/element-web/pull/14924
