### PR TITLE
Make the tray icon blink on unread messages

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -215,6 +215,7 @@ async function setupGlobals() {
     trayConfig = {
         icon_path: iconPath,
         brand: vectorConfig.brand || 'Element',
+        blinkEnabled: store.get('trayIconBlinkEnabled'),
     };
 
     // launcher
@@ -352,6 +353,13 @@ ipcMain.on('ipcCall', async function(ev, payload) {
                 tray.destroy();
             }
             store.set('minimizeToTray', args[0]);
+            break;
+        case 'getTrayIconBlinkEnabled':
+            ret = store.get('trayIconBlinkEnabled');
+            break;
+        case 'setTrayIconBlinkEnabled':
+            store.set('trayIconBlinkEnabled', args[0]);
+            tray.setEnableBlinking(args[0]);
             break;
         case 'getAutoHideMenuBarEnabled':
             ret = global.mainWindow.autoHideMenuBar;


### PR DESCRIPTION
This pull request (together with appropriate PRs in two other repos) adds a new option and functionality, allowing the user to enable tray icon blinking when there are unread messages pending. Blinking stops as soon as there are no unread messages or if the option is explicitly turned off in the settings. Our users sometimes miss the messages because the red circle with a number doesn't attract their attention. We used Gajim (an XMPP client) before and its icon blinks on new messages so they always notice it. This option is off by default so it's completely opt-in.

What it looks like: https://www.youtube.com/watch?v=1n2LEZqwZRw

Signed-off-by: Sergey Shpikin <rkfg@rkfg.me>

---

Fixes https://github.com/vector-im/element-desktop/issues/769
Depends on https://github.com/vector-im/element-web/pull/15015
Depends on https://github.com/matrix-org/matrix-react-sdk/pull/5135

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->