### PR TITLE
Upgrade to Electron 10.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "9.1.2",
+    "electronVersion": "10.1.1",
     "files": [
       "package.json",
       {


### PR DESCRIPTION
Release notes seem generally safe from a quick scan. Verified working on macOS only so far.