### PR TITLE
Connect to a server using TLS client authentication

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -1002,7 +1002,7 @@ app.on('select-client-certificate', (event, webContents, url, list, callback) =>
                 break;
             }
         }
-        if(found === false) {
+        if (found === false) {
             console.log('No certificate found');
         }
     } else if (clientCertPickFirst === true && list.length > 0) {
@@ -1012,13 +1012,13 @@ app.on('select-client-certificate', (event, webContents, url, list, callback) =>
     } else {
       console.log('No client certificate available');
     }
-})
+});
 
 app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
     // Ensure we don't trust certificate causing a verification error
     console.log('Untrusted server certificate');
     callback(false);
-})
+});
 
 function beforeQuit() {
     global.appQuitting = true;

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -993,7 +993,7 @@ app.on('select-client-certificate', (event, webContents, url, list, callback) =>
 
     if (clientCertFingerprint) {
         let found = false
-			  for (const cert of list) {
+            for (const cert of list) {
             if (cert.fingerprint === clientCertFingerprint) {
                 console.log('Selected client certificate ' + cert.fingerprint)
                 event.preventDefault()
@@ -1005,7 +1005,7 @@ app.on('select-client-certificate', (event, webContents, url, list, callback) =>
         if(found === false) {
             console.log('No certificate found')
         }
-		} else if (clientCertPickFirst === true && list.length > 0) {
+    } else if (clientCertPickFirst === true && list.length > 0) {
         console.log('Selected first available client certificate ' + list[0].fingerprint)
         event.preventDefault()
         callback(list[0])

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -985,6 +985,41 @@ app.on('activate', () => {
     mainWindow.show();
 });
 
+app.on('select-client-certificate', (event, webContents, url, list, callback) => {
+    console.log('select-client-certificate', url, list)
+
+    const clientCertPickFirst = vectorConfig['clientCertPickFirst']
+    const clientCertFingerprint = vectorConfig['clientCertFingerprint']
+
+    if (clientCertFingerprint) {
+        let found = false
+			  for (const cert of list) {
+            if (cert.fingerprint === clientCertFingerprint) {
+                console.log('Selected client certificate ' + cert.fingerprint)
+                event.preventDefault()
+                callback(cert)
+                found = true
+                break
+            }
+        }
+        if(found === false) {
+            console.log('No certificate found')
+        }
+		} else if (clientCertPickFirst === true && list.length > 0) {
+        console.log('Selected first available client certificate ' + list[0].fingerprint)
+        event.preventDefault()
+        callback(list[0])
+    } else {
+      console.log('No client certificate available')
+    }
+})
+
+app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+    // Ensure we don't trust certificate causing a verification error
+    console.log('Untrusted server certificate')
+    callback(false)
+})
+
 function beforeQuit() {
     global.appQuitting = true;
     if (mainWindow) {

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -986,38 +986,38 @@ app.on('activate', () => {
 });
 
 app.on('select-client-certificate', (event, webContents, url, list, callback) => {
-    console.log('select-client-certificate', url, list)
+    console.log('select-client-certificate', url, list);
 
-    const clientCertPickFirst = vectorConfig['clientCertPickFirst']
-    const clientCertFingerprint = vectorConfig['clientCertFingerprint']
+    const clientCertPickFirst = vectorConfig['clientCertPickFirst'];
+    const clientCertFingerprint = vectorConfig['clientCertFingerprint'];
 
     if (clientCertFingerprint) {
-        let found = false
+        let found = false;
             for (const cert of list) {
             if (cert.fingerprint === clientCertFingerprint) {
-                console.log('Selected client certificate ' + cert.fingerprint)
-                event.preventDefault()
-                callback(cert)
-                found = true
-                break
+                console.log('Selected client certificate ' + cert.fingerprint);
+                event.preventDefault();
+                callback(cert);
+                found = true;
+                break;
             }
         }
         if(found === false) {
-            console.log('No certificate found')
+            console.log('No certificate found');
         }
     } else if (clientCertPickFirst === true && list.length > 0) {
-        console.log('Selected first available client certificate ' + list[0].fingerprint)
-        event.preventDefault()
-        callback(list[0])
+        console.log('Selected first available client certificate ' + list[0].fingerprint);
+        event.preventDefault();
+        callback(list[0]);
     } else {
-      console.log('No client certificate available')
+      console.log('No client certificate available');
     }
 })
 
 app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
     // Ensure we don't trust certificate causing a verification error
-    console.log('Untrusted server certificate')
-    callback(false)
+    console.log('Untrusted server certificate');
+    callback(false);
 })
 
 function beforeQuit() {


### PR DESCRIPTION
Hi there and before all thanks a lot for this great app :+1: 

This PR aims to enable connecting to a synapse instance with TLS client authentication. A use case for doing such a thing is to have a convenient way to mitigate potential synapse/matrix security vulnerability by restricting access to the API. A somehow friendlier alternative as using some sort of tunnelling and/or firewalling. With this PR a user can install a client certificate in his local store and it will be used by the desktop client.

At the moment the way we are doing this is via hosting the element-web client on the same endpoint as the matrix synapse server. The element-web client served via matrix/synapse through a reverse proxy with TLS client authentication is working just fine. Albeit most of our users prefer the desktop version for various reasons hence this PR.

I am no JS dev so apologies in advance if I made some beginner mistakes here. Also I am no guru when it comes to certificate validation, hence I would like to open a discussion if this is something that could be added to the desktop client. And if it is, how to do this correctly.

PS: I am not sure where element features are consolidated so apologies if this is not the right place.

