### PR TITLE
Revert back to the 10.x series

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "11.0.3",
+    "electronVersion": "10.1.6",
     "files": [
       "package.json",
       {


### PR DESCRIPTION
The latest 11.x still exhibits
https://github.com/vector-im/element-web/issues/15869, so let's try the latest
10.x version instead.