### PR TITLE
Enable context isolation, bridge expected IPC

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -1,9 +1,8 @@
 /*
 Copyright 2016 Aviral Dasgupta
 Copyright 2016 OpenMarket Ltd
-Copyright 2018, 2019 New Vector Ltd
 Copyright 2017, 2019 Michael Telatynski <7t3chguy@gmail.com>
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2018 - 2021 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -922,11 +921,7 @@ app.on('ready', async () => {
             nodeIntegration: false,
             //sandbox: true, // We enable sandboxing from app.enableSandbox() above
             enableRemoteModule: false,
-            // We don't use this: it's useful for the preload script to
-            // share a context with the main page so we can give select
-            // objects to the main page. The sandbox option isolates the
-            // main page from the background script.
-            contextIsolation: false,
+            contextIsolation: true,
             webgl: false,
             spellcheck: true,
         },


### PR DESCRIPTION
This enables Electron's context isolation mode as recommended in their guidance.
We use the context bridge feature to regain access to only the IPC channels we
expect to have access to.

Used by https://github.com/vector-im/element-web/pull/16137