### PR TITLE
Remove Debian dependency libappindicator3-1

### DIFF
--- a/element.io/nightly/control.template
+++ b/element.io/nightly/control.template
@@ -3,7 +3,7 @@ License: Apache-2.0
 Vendor: support@element.io
 Architecture: amd64
 Maintainer: support@element.io
-Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libappindicator3-1, libsecret-1-0, libsqlcipher0
+Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0, libsqlcipher0
 Section: net
 Priority: extra
 Homepage: https://element.io/

--- a/element.io/nightly/control.template
+++ b/element.io/nightly/control.template
@@ -4,6 +4,7 @@ Vendor: support@element.io
 Architecture: amd64
 Maintainer: support@element.io
 Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0, libsqlcipher0
+Recommends: libappindicator3-1
 Section: net
 Priority: extra
 Homepage: https://element.io/

--- a/element.io/release/control.template
+++ b/element.io/release/control.template
@@ -3,7 +3,7 @@ License: Apache-2.0
 Vendor: support@element.io
 Architecture: amd64
 Maintainer: support@element.io
-Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libappindicator3-1, libsecret-1-0, libsqlcipher0
+Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0, libsqlcipher0
 Replaces: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)
 Breaks: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)
 Section: net

--- a/element.io/release/control.template
+++ b/element.io/release/control.template
@@ -4,6 +4,7 @@ Vendor: support@element.io
 Architecture: amd64
 Maintainer: support@element.io
 Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0, libsqlcipher0
+Recommends: libappindicator3-1
 Replaces: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)
 Breaks: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)
 Section: net


### PR DESCRIPTION
libappindicator has been deprecated by Debian (0) and will not be shipped from
Debian Bullseye on.

This library is supposed to enable the system tray icon to work, but it actually works fine without it on the two systems I've been able to test (xfce / i3). At the same time, this dependency prevents users from installing element-desktop on Debian Bullseye.

0: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037