### PR TITLE
Add prompt to warn before quitting the application

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -27,7 +27,9 @@ const argv = require('minimist')(process.argv, {
     alias: {help: "h"},
 });
 
-const {app, ipcMain, powerSaveBlocker, BrowserWindow, Menu, autoUpdater, protocol, dialog} = require('electron');
+const {
+    app, ipcMain, powerSaveBlocker, BrowserWindow, Menu, autoUpdater, protocol, dialog, globalShortcut,
+} = require('electron');
 const AutoLaunch = require('auto-launch');
 const path = require('path');
 
@@ -253,6 +255,22 @@ let eventIndex = null;
 let mainWindow = null;
 global.appQuitting = false;
 
+const warnBeforeExit = (event) => {
+    if (store.get('warnBeforeExit', true)) {
+        const shouldCancelCloseRequest = dialog.showMessageBoxSync(mainWindow, {
+            type: "question",
+            buttons: ["Cancel", "Close Element"],
+            message: "Are you sure you want to quit?",
+            defaultId: 1,
+            cancelId: 0,
+        }) === 0;
+
+        if (shouldCancelCloseRequest) {
+            event.preventDefault();
+            return false;
+        }
+    }
+};
 
 const deleteContents = async (p) => {
     for (const entry of await afs.readdir(p)) {
@@ -923,6 +941,12 @@ app.on('ready', async () => {
         }
     });
 
+    globalShortcut.register("CommandOrControl+Q", warnBeforeExit);
+    if (process.platform !== 'darwin') {
+        globalShortcut.register("Alt+F4", warnBeforeExit);
+        globalShortcut.register("AltGr+F4 ", warnBeforeExit);
+    }
+
     mainWindow.on('closed', () => {
         mainWindow = global.mainWindow = null;
     });
@@ -935,21 +959,6 @@ app.on('ready', async () => {
             e.preventDefault();
             mainWindow.hide();
             return false;
-        }
-
-        if (store.get('warnBeforeExit', true)) {
-            const shouldCancelCloseRequest = dialog.showMessageBoxSync(mainWindow, {
-                type: "question",
-                buttons: ["Cancel", "Close Element"],
-                message: "Are you sure you want to quit?",
-                defaultId: 1,
-                cancelId: 0,
-            }) === 0;
-
-            if (shouldCancelCloseRequest) {
-                e.preventDefault();
-                return false;
-            }
         }
     });
 

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -340,6 +340,12 @@ ipcMain.on('ipcCall', async function(ev, payload) {
                 launcher.disable();
             }
             break;
+        case 'shouldWarnBeforeExit':
+            ret = store.get('warnBeforeExit', true);
+            break;
+        case 'setWarnBeforeExit':
+            store.set('warnBeforeExit', args[0]);
+            break;
         case 'getMinimizeToTrayEnabled':
             ret = tray.hasTray();
             break;
@@ -921,19 +927,21 @@ app.on('ready', async () => {
         mainWindow = global.mainWindow = null;
     });
     mainWindow.on('close', async (e) => {
-        const shouldCancelCloseRequest = dialog.showMessageBoxSync(mainWindow, {
-            type: "question",
-            buttons: ["Cancel", "Close Element"],
-            message: "Are you sure you want to quit?",
-            defaultId: 1,
-            cancelId: 0,
-            checkboxLabel: "Do not show this again",
-            checkboxChecked: false,
-        }) === 0;
+        if (store.get('warnBeforeExit', true)) {
+            const shouldCancelCloseRequest = dialog.showMessageBoxSync(mainWindow, {
+                type: "question",
+                buttons: ["Cancel", "Close Element"],
+                message: "Are you sure you want to quit?",
+                defaultId: 1,
+                cancelId: 0,
+                checkboxLabel: "Do not show this again",
+                checkboxChecked: false,
+            }) === 0;
 
-        if (shouldCancelCloseRequest) {
-            e.preventDefault();
-            return false;
+            if (shouldCancelCloseRequest) {
+                e.preventDefault();
+                return false;
+            }
         }
 
         // If we are not quitting and have a tray icon then minimize to tray

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -27,7 +27,7 @@ const argv = require('minimist')(process.argv, {
     alias: {help: "h"},
 });
 
-const {app, ipcMain, powerSaveBlocker, BrowserWindow, Menu, autoUpdater, protocol} = require('electron');
+const {app, ipcMain, powerSaveBlocker, BrowserWindow, Menu, autoUpdater, protocol, dialog} = require('electron');
 const AutoLaunch = require('auto-launch');
 const path = require('path');
 
@@ -920,7 +920,22 @@ app.on('ready', async () => {
     mainWindow.on('closed', () => {
         mainWindow = global.mainWindow = null;
     });
-    mainWindow.on('close', (e) => {
+    mainWindow.on('close', async (e) => {
+        const shouldCancelCloseRequest = dialog.showMessageBoxSync(mainWindow, {
+            type: "question",
+            buttons: ["Cancel", "Close Element"],
+            message: "Are you sure you want to quit?",
+            defaultId: 1,
+            cancelId: 0,
+            checkboxLabel: "Do not show this again",
+            checkboxChecked: false,
+        }) === 0;
+
+        if (shouldCancelCloseRequest) {
+            e.preventDefault();
+            return false;
+        }
+
         // If we are not quitting and have a tray icon then minimize to tray
         if (!global.appQuitting && (tray.hasTray() || process.platform === 'darwin')) {
             // On Mac, closing the window just hides it

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -934,8 +934,6 @@ app.on('ready', async () => {
                 message: "Are you sure you want to quit?",
                 defaultId: 1,
                 cancelId: 0,
-                checkboxLabel: "Do not show this again",
-                checkboxChecked: false,
             }) === 0;
 
             if (shouldCancelCloseRequest) {

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -927,6 +927,16 @@ app.on('ready', async () => {
         mainWindow = global.mainWindow = null;
     });
     mainWindow.on('close', async (e) => {
+        // If we are not quitting and have a tray icon then minimize to tray
+        if (!global.appQuitting && (tray.hasTray() || process.platform === 'darwin')) {
+            // On Mac, closing the window just hides it
+            // (this is generally how single-window Mac apps
+            // behave, eg. Mail.app)
+            e.preventDefault();
+            mainWindow.hide();
+            return false;
+        }
+
         if (store.get('warnBeforeExit', true)) {
             const shouldCancelCloseRequest = dialog.showMessageBoxSync(mainWindow, {
                 type: "question",
@@ -940,16 +950,6 @@ app.on('ready', async () => {
                 e.preventDefault();
                 return false;
             }
-        }
-
-        // If we are not quitting and have a tray icon then minimize to tray
-        if (!global.appQuitting && (tray.hasTray() || process.platform === 'darwin')) {
-            // On Mac, closing the window just hides it
-            // (this is generally how single-window Mac apps
-            // behave, eg. Mail.app)
-            e.preventDefault();
-            mainWindow.hide();
-            return false;
         }
     });
 


### PR DESCRIPTION
Fixes vector-im/element-web#16620

Related pull requests
* matrix-org/matrix-react-sdk#5793
* vector-im/element-web#16781

![Screen Shot 2021-03-23 at 08 09 44](https://user-images.githubusercontent.com/769871/112488175-3a13d380-8d75-11eb-90b5-195383347d0f.png)
The final copy is:
* Message: Are you sure you want to quit?
* No: Cancel
* Yes: Close Element

We originally wanted to implement a different UI, however due to the nature of JavaScript and how the `keyup` event is triggered, we had to choose this approach. View the original ticket if you are interested in the full context

I also wanted to add a checkbox letting the user opt-out from that warning dialog. This has proven quite difficult as we do have to use `dialog.showMessageBoxSync` and that this option seems to be only available with `dialog.showMessageBox` despite what the documentation says (I opened a ticket electron/electron#28394)

Lastly, there are no references to i18n in the `element-desktop` repo, and the menu items do not get translated either. To not drastically increase the scope of this ticket I intentionally left that out