### PR TITLE
Add reset logic for corrupted event index store

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -471,6 +471,7 @@ ipcMain.on('seshat', async function(ev, payload) {
 
     const args = payload.args || [];
     let ret;
+    let err;
 
     switch (payload.name) {
         case 'supportsEventIndexing':
@@ -732,6 +733,17 @@ ipcMain.on('seshat', async function(ev, payload) {
             }
             break;
 
+        case 'resetEventStore':
+            err = await fs.promises.rmdir(eventStorePath, { recursive: true });
+            if (!err) {
+                console.log("Seshat Event Store successfully deleted");
+                app.relaunch();
+                app.exit();
+            } else {
+                console.error("An error occurred deleting Seshat Event Store", err);
+                sendError(payload.id, err);
+            }
+            break;
         default:
             mainWindow.webContents.send('seshatReply', {
                 id: payload.id,


### PR DESCRIPTION
Fixes vector-im/element-web#14229

Related pull requests
* vector-im/element-web#16792
* matrix-org/matrix-react-sdk#5806

The event index store can sometimes get corrupted for [various reasons...](https://github.com/matrix-org/seshat/blob/master/src/error.rs#L22)

Many people suggested that a fix that worked for them was to delete the event store index and restart the application