### PR TITLE
Fix disabling spellchecker

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -411,17 +411,25 @@ ipcMain.on('ipcCall', async function(ev, payload) {
             break;
         case 'setSpellCheckLanguages':
             if (args[0] && args[0].length > 0) {
+                mainWindow.webContents.session.setSpellCheckerEnabled(true);
+                store.set("spellCheckerEnabled", true);
+
                 try {
                     mainWindow.webContents.session.setSpellCheckerLanguages(args[0]);
                 } catch (er) {
                     console.log("There were problems setting the spellcheck languages", er);
                 }
             } else {
-                mainWindow.webContents.session.setSpellCheckerLanguages([]);
+                mainWindow.webContents.session.setSpellCheckerEnabled(false);
+                store.set("spellCheckerEnabled", false);
             }
             break;
         case 'getSpellCheckLanguages':
-            ret = mainWindow.webContents.session.getSpellCheckerLanguages();
+            if (store.get("spellCheckerEnabled", true)) {
+                ret = mainWindow.webContents.session.getSpellCheckerLanguages();
+            } else {
+                ret = [];
+            }
             break;
         case 'getAvailableSpellCheckLanguages':
             ret = mainWindow.webContents.session.availableSpellCheckerLanguages;
@@ -921,11 +929,14 @@ app.on('ready', async () => {
             enableRemoteModule: false,
             contextIsolation: true,
             webgl: false,
-            spellcheck: true,
         },
     });
     mainWindow.loadURL('vector://vector/webapp/');
     Menu.setApplicationMenu(vectorMenu);
+
+    // Handle spellchecker
+    // For some reason spellCheckerEnabled isn't persisted so we have to use the store here
+    mainWindow.webContents.session.setSpellCheckerEnabled(store.get("spellCheckerEnabled", true));
 
     // Create trayIcon icon
     if (store.get('minimizeToTray', true)) tray.create(trayConfig);


### PR DESCRIPTION
Fixes [#16632](https://github.com/vector-im/element-web/issues/16632)

This is quite ugly. We have to use the store here to get this working since `spellCheckerEnabled` doesn't seem to be persistent.