### PR TITLE
Disables HardwareMediaKeyHandling

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -814,6 +814,7 @@ protocol.registerSchemesAsPrivileged([{
 // transition into the user's browser.
 app.enableSandbox();
 
+// We disable media controls here. We do this because calls use audio and video elements and they sometimes capture the media keys. See https://github.com/vector-im/element-web/issues/15704
 app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling,MediaSessionService');
 
 app.on('ready', async () => {

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -814,6 +814,8 @@ protocol.registerSchemesAsPrivileged([{
 // transition into the user's browser.
 app.enableSandbox();
 
+app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling,MediaSessionService');
+
 app.on('ready', async () => {
     try {
         await setupGlobals();


### PR DESCRIPTION
This should fix vector-im/element-web#15704 as suggested by [tretum](https://github.com/vector-im/element-web/issues/15704#issuecomment-734403526).

PS: This is a quick fix. IMO it should be possible to add (via a config file or in-app settings) random flags like this one that electron supports. But that is a different story.