### PR TITLE
Fix using yarn run fetch with a specific version

### DIFF
--- a/scripts/fetch-package.js
+++ b/scripts/fetch-package.js
@@ -15,7 +15,7 @@ const PUB_KEY_URL = "https://packages.riot.im/element-release-key.asc";
 const PACKAGE_URL_PREFIX = "https://github.com/vector-im/element-web/releases/download/";
 const ASAR_PATH = 'webapp.asar';
 
-const {setPackageVersion, setDebVersion} = require('./set-version.js');
+const setPackageVersion = require('./set-version.js');
 
 async function getLatestDevelopUrl(bkToken) {
     const buildsResult = await needle('get',
@@ -283,7 +283,6 @@ async function main() {
         const semVer = targetVersion.slice(1);
         console.log("Updating version to " + semVer);
         await setPackageVersion(semVer);
-        await setDebVersion(semVer);
     }
 
     console.log("Done!");

--- a/scripts/fetch-package.js
+++ b/scripts/fetch-package.js
@@ -15,7 +15,7 @@ const PUB_KEY_URL = "https://packages.riot.im/element-release-key.asc";
 const PACKAGE_URL_PREFIX = "https://github.com/vector-im/element-web/releases/download/";
 const ASAR_PATH = 'webapp.asar';
 
-const setPackageVersion = require('./set-version.js');
+const {setPackageVersion} = require('./set-version.js');
 
 async function getLatestDevelopUrl(bkToken) {
     const buildsResult = await needle('get',


### PR DESCRIPTION
Using `yarn run fetch` is currently broken when a version other than `develop` is given. `setDebVersion` is the culprit, as that was removed in commit a1366992bc512418af7b71251d237519eb5180c1.

This removes the last remnants of `setDebVersion`.