### PR TITLE
Fix exit shortcuts for non QWERTY keyboards

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -256,9 +256,9 @@ let mainWindow = null;
 global.appQuitting = false;
 
 const exitShortcuts = [
-    (input, platform) => platform !== 'darwin' && input.alt && input.code === 'F4',
-    (input, platform) => platform !== 'darwin' && input.control && input.code === 'KeyQ',
-    (input, platform) => platform === 'darwin' && input.meta && input.code === 'KeyQ',
+    (input, platform) => platform !== 'darwin' && input.alt && input.key.toUpperCase() === 'F4',
+    (input, platform) => platform !== 'darwin' && input.control && input.key.toUpperCase() === 'Q',
+    (input, platform) => platform === 'darwin' && input.meta && input.key.toUpperCase() === 'Q',
 ];
 
 const warnBeforeExit = (event, input) => {


### PR DESCRIPTION
Fixes vector-im/element-web#16938

I was unfortunately using [`KeyboardEvent.code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code). When reading through the MDN documentation there is a fair warning saying

> Warning: This ignores the user's keyboard layout, so that if the user presses the key at the "Y" position in a QWERTY keyboard layout (near the middle of the row above the home row), this will always return "KeyY", even if the user has a QWERTZ keyboard (which would mean the user expects a "Z" and all the other properties would indicate a "Z") or a Dvorak keyboard layout (where the user would expect an "F").

