### PR TITLE
Add Windows native module requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ yarn run build:native
 ```
 
 On Windows, this will automatically determine the architecture to build for based
-on the environment (ie. set up by vcvarsall.bat).
+on the environment. Make sure that you have all the [tools required to perform the native modules build](docs/windows-requirements.md)
 
 Now you can build the package:
 

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -1,0 +1,23 @@
+# Windows
+
+## Requirements to build native modules
+
+If you want to build native modules, make sure that the following tools are installed on your system.
+
+- [Node 14](https://nodejs.org)
+- [Python 3](https://www.python.org/downloads/)
+- [Strawberry Perl](https://strawberryperl.com/)
+- [Rust](https://rustup.rs/)
+- [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the following packages
+  - MSVC VS 2019 C++
+  - Windows 10 SDK
+  - C++ Clang tools
+
+Once installed make sure all those utilities are accessible in your `PATH`.
+In order to load all the C++ utilities installed by Visual Studio you can run the following in a terminal window.
+
+```
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
+```
+
+You can replace `amd64` with `x86` depending on your CPU architecture.


### PR DESCRIPTION
After a long and painful journey to setup a Windows VM, here are my findings compiled to allow one to build native modules locally

I am not an expert regarding Visual Studio versions, so I would definitely be keen to hear your suggestions on what would be relevant there