### PR TITLE
Put Preferences menu item in correct location on macOS

### DIFF
--- a/src/vectormenu.js
+++ b/src/vectormenu.js
@@ -17,6 +17,8 @@ limitations under the License.
 const { app, shell, Menu } = require('electron');
 const { _t } = require('./language-helper');
 
+const isMac = process.platform === 'darwin';
+
 function buildMenuTemplate() {
     // Menu template from http://electron.atom.io/docs/api/menu/, edited
     const template = [
@@ -78,11 +80,11 @@ function buildMenuTemplate() {
                     label: _t('Zoom Out'),
                 },
                 { type: 'separator' },
-                {
+                // in macOS the Preferences menu item goes in the first menu
+                ...(!isMac ? [{
                     label: _t('Preferences'),
-                    accelerator: 'Command+,', // Mac-only accelerator
                     click() { global.mainWindow.webContents.send('preferences'); },
-                },
+                }] : []),
                 {
                     role: 'togglefullscreen',
                     label: _t('Toggle Full Screen'),
@@ -122,7 +124,7 @@ function buildMenuTemplate() {
     ];
 
     // macOS has specific menu conventions...
-    if (process.platform === 'darwin') {
+    if (isMac) {
         template.unshift({
             // first macOS menu is the name of the app
             role: 'appMenu',
@@ -131,6 +133,12 @@ function buildMenuTemplate() {
                 {
                     role: 'about',
                     label: _t('About'),
+                },
+                { type: 'separator' },
+                {
+                    label: _t('Preferences'),
+                    accelerator: 'Command+,', // Mac-only accelerator
+                    click() { global.mainWindow.webContents.send('preferences'); },
                 },
                 { type: 'separator' },
                 {

--- a/src/vectormenu.js
+++ b/src/vectormenu.js
@@ -132,11 +132,11 @@ function buildMenuTemplate() {
             submenu: [
                 {
                     role: 'about',
-                    label: _t('About'),
+                    label: _t('About') + ' ' + app.name,
                 },
                 { type: 'separator' },
                 {
-                    label: _t('Preferences'),
+                    label: _t('Preferences') + '…',
                     accelerator: 'Command+,', // Mac-only accelerator
                     click() { global.mainWindow.webContents.send('preferences'); },
                 },


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17549

This has only been tested on macOS.

<img width="170" src="https://user-images.githubusercontent.com/5855073/120743816-55126a80-c4bf-11eb-934b-4e2f13d9ef2e.png">
<img width="235" src="https://user-images.githubusercontent.com/5855073/120743807-52177a00-c4bf-11eb-949c-9afe46642500.png">


