### PR TITLE
Add warning dialog when custom config.json is invalid

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -210,10 +210,9 @@ async function setupGlobals() {
         if (e instanceof SyntaxError) {
             dialog.showMessageBox({
                 type: "error",
-                title: _t("Your %(brand)s is misconfigured", { brand: vectorConfig.brand || 'Element' }),
-                message: _t("Your custom %(brand)s configuration contains invalid JSON. " +
-                            "Please correct the problem and reopen %(brand)s.",
-                            { brand: vectorConfig.brand || 'Element' }),
+                title: `Your ${vectorConfig.brand || 'Element'} is misconfigured`,
+                message: `Your custom ${vectorConfig.brand || 'Element'} configuration contains invalid JSON. ` +
+                         `Please correct the problem and reopen ${vectorConfig.brand || 'Element'}.`,
                 detail: e.message || "",
             });
         }

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -210,9 +210,10 @@ async function setupGlobals() {
         if (e instanceof SyntaxError) {
             dialog.showMessageBox({
                 type: "error",
-                title: _t("Your %(brand)s is misconfigured", { brand: vectorConfig.brand || 'Element'}),
+                title: _t("Your %(brand)s is misconfigured", { brand: vectorConfig.brand || 'Element' }),
                 message: _t("Your custom %(brand)s configuration contains invalid JSON. " +
-                            "Please correct the problem and reopen %(brand)s.", { brand: vectorConfig.brand || 'Element'}),
+                            "Please correct the problem and reopen %(brand)s.",
+                            { brand: vectorConfig.brand || 'Element' }),
                 detail: e.message || "",
             });
         }

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -207,6 +207,16 @@ async function setupGlobals() {
 
         vectorConfig = Object.assign(vectorConfig, localConfig);
     } catch (e) {
+        if (e instanceof SyntaxError) {
+            dialog.showMessageBox({
+                type: "error",
+                title: _t("Your %(brand)s is misconfigured", { brand: vectorConfig.brand || 'Element'}),
+                message: _t("Your custom %(brand)s configuration contains invalid JSON. " +
+                            "Please correct the problem and reopen %(brand)s.", { brand: vectorConfig.brand || 'Element'}),
+                detail: e.message || "",
+            });
+        }
+
         // Could not load local config, this is expected in most cases.
     }
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1,4 +1,6 @@
 {
+    "Your %(brand)s is misconfigured": "Your %(brand)s is misconfigured",
+    "Your custom %(brand)s configuration contains invalid JSON. Please correct the problem and reopen %(brand)s.": "Your custom %(brand)s configuration contains invalid JSON. Please correct the problem and reopen %(brand)s.",
     "Cancel": "Cancel",
     "Close Element": "Close Element",
     "Are you sure you want to quit?": "Are you sure you want to quit?",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1,6 +1,4 @@
 {
-    "Your %(brand)s is misconfigured": "Your %(brand)s is misconfigured",
-    "Your custom %(brand)s configuration contains invalid JSON. Please correct the problem and reopen %(brand)s.": "Your custom %(brand)s configuration contains invalid JSON. Please correct the problem and reopen %(brand)s.",
     "Cancel": "Cancel",
     "Close Element": "Close Element",
     "Are you sure you want to quit?": "Are you sure you want to quit?",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17476

I don't know enough about error handling to pass the error along to the existing "Your Element is misconfigured" page that the web version shows
<img width="755" src="https://user-images.githubusercontent.com/5855073/120746706-5cd50d80-c4c5-11eb-93d6-c8ed2c928143.png">

but I think showing this dialog box during start will work fine.

<img width="328" src="https://user-images.githubusercontent.com/5855073/120746822-973eaa80-c4c5-11eb-8fb8-1fcd09807088.png">

I'm not sure why the translation isn't working. I'll need some help getting that working.
