### PR TITLE
Switch zoomIn accelerator to default

### DIFF
--- a/src/vectormenu.js
+++ b/src/vectormenu.js
@@ -70,8 +70,6 @@ function buildMenuTemplate() {
                 },
                 {
                     role: 'zoomin',
-                    accelerator: 'CommandOrControl+=',
-                    accelerator: 'CommandOrControl+Plus',
                     label: _t('Zoom In'),
                 },
                 {

--- a/src/vectormenu.js
+++ b/src/vectormenu.js
@@ -71,6 +71,7 @@ function buildMenuTemplate() {
                 {
                     role: 'zoomin',
                     accelerator: 'CommandOrControl+=',
+                    accelerator: 'CommandOrControl+Plus',
                     label: _t('Zoom In'),
                 },
                 {


### PR DESCRIPTION
Sometime since https://github.com/vector-im/element-web/pull/8381 Electron has fixed the bug where zoomin did not work with both ⌘+ and ⌘=

Fixes https://github.com/vector-im/element-web/issues/17104

Maybe https://github.com/vector-im/element-web/issues/9533