### PR TITLE
Add numpad accelerators for zooming

### DIFF
--- a/src/vectormenu.js
+++ b/src/vectormenu.js
@@ -68,6 +68,21 @@ function buildMenuTemplate() {
                 { type: 'separator' },
                 {
                     role: 'resetzoom',
+                    accelerator: 'CmdOrCtrl+Num0',
+                    visible: false,
+                },
+                {
+                    role: 'zoomin',
+                    accelerator: 'CmdOrCtrl+NumAdd',
+                    visible: false,
+                },
+                {
+                    role: 'zoomout',
+                    accelerator: 'CmdOrCtrl+NumSub',
+                    visible: false,
+                },
+                {
+                    role: 'resetzoom',
                     label: _t('Actual Size'),
                 },
                 {


### PR DESCRIPTION
This is a small temporary fix for this issue (vector-im/element-web#9533), because Electron doesn't let you use multiple accelerators yet. Because the numpad menuitems are invisible, they won't show up in the menu but will work like in the example below.

https://user-images.githubusercontent.com/486818/120871406-32a64d00-c5a4-11eb-9066-1656bf3b338c.mp4