### PR TITLE
Upgrade to Node 14

### DIFF
--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -30,7 +30,7 @@ ENV LC_ALL C.UTF-8
 
 ENV DEBUG_COLORS true
 ENV FORCE_COLOR true
-ENV NODE_VERSION 12.16.1
+ENV NODE_VERSION 14.17.0
 
 # this package is used for snapcraft and we should not clear apt list - to avoid apt-get update during snap build
 RUN curl -L https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz | tar xz -C /usr/local --strip-components=1 && \


### PR DESCRIPTION
The newer `electron-builder` we're now using as of https://github.com/vector-im/element-desktop/pull/204 requires a minimum Node version of 14.17.0.