### PR TITLE
Don't show Quit warning on keyUp residual event

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -264,7 +264,8 @@ const exitShortcuts = [
 
 const warnBeforeExit = (event, input) => {
     const shouldWarnBeforeExit = store.get('warnBeforeExit', true);
-    const exitShortcutPressed = exitShortcuts.some(shortcutFn => shortcutFn(input, process.platform));
+    const exitShortcutPressed =
+        input.type === 'keyDown' && exitShortcuts.some(shortcutFn => shortcutFn(input, process.platform));
 
     if (shouldWarnBeforeExit && exitShortcutPressed) {
         const shouldCancelCloseRequest = dialog.showMessageBoxSync(mainWindow, {


### PR DESCRIPTION
The warning triggered whenever the app got focus after another window was closed with a Ctrl+Q shortcut and the keys were then released.

Hitting the 'Close Element' button didn't even close the app in this case, as only the warning handler was triggered, not the actual quit shortcut (which does discriminate between key press and key release).

Actually checking for 'keyDown' should prevent this from occurring again.

Fixes vector-im/element-web#17714