### PR TITLE
Fix the build: make the rootDir correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "docker:build": "scripts/in-docker.sh yarn run build",
     "docker:install": "scripts/in-docker.sh yarn install",
     "debrepo": "scripts/mkrepo.sh",
-    "clean": "rimraf webapp.asar dist packages deploys",
+    "clean": "rimraf webapp.asar dist packages deploys lib",
     "hak": "node scripts/hak/index.js"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "allowJs": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2016",
     "noImplicitAny": false,
     "sourceMap": false,
     "outDir": "./lib",
+    "rootDir": "./src",
     "declaration": true,
     "types": [
       "node"
@@ -19,7 +19,6 @@
     ]
   },
   "include": [
-    ".eslintrc.js",
     "./src/**/*.ts"
   ]
 }


### PR DESCRIPTION
https://github.com/vector-im/element-desktop/pull/223 added `allowJs: true` which meant that the `.eslintrc.js` specified in `include` started actually being included, which meant the implicit root dir was `.` rather than `src/`.

We shouldn't need to copy `.eslintrc.js` to lib, so remove it, and we don't have any js source files left, so we don't need `allowJs`. Also add an explicit `rootDir` which isn't necessary but feels like it makes things a lot clearer and will prevent such confusion in the the future.