### PR TITLE
Check target with rustc directly

### DIFF
--- a/hak/matrix-seshat/check.js
+++ b/hak/matrix-seshat/check.js
@@ -70,7 +70,8 @@ module.exports = async function(hakEnv, moduleInfo) {
             if (err) {
                 reject(
                     "rustc can't build for target " + hakEnv.getTargetId() +
-                    ": ensure the correct toolchain is installed",
+                    ": ensure target is installed via `rustup target add " + hakEnv.getTargetId() + "` " +
+                    "or your package manager if not using `rustup`",
                 );
             }
             fsProm.unlink('tmp').then(resolve);

--- a/hak/matrix-seshat/check.js
+++ b/hak/matrix-seshat/check.js
@@ -64,9 +64,14 @@ module.exports = async function(hakEnv, moduleInfo) {
 
     // Ensure Rust target exists (nb. we avoid depending on rustup)
     await new Promise((resolve, reject) => {
-        const rustc = childProcess.execFile('rustc', ['--target', hakEnv.getTargetId(), '-o', 'tmp', '-'], (err, out) => {
+        const rustc = childProcess.execFile('rustc', [
+            '--target', hakEnv.getTargetId(), '-o', 'tmp', '-',
+        ], (err, out) => {
             if (err) {
-                reject("rustc can't build for target " + hakEnv.getTargetId() + ": ensure the correct toolchain is installed");
+                reject(
+                    "rustc can't build for target " + hakEnv.getTargetId() +
+                    ": ensure the correct toolchain is installed",
+                );
             }
             fsProm.unlink('tmp').then(resolve);
         });


### PR DESCRIPTION
To avoid depending on rustup (at least when not cross-compiling)

Fixes https://github.com/vector-im/element-web/issues/17885