### PR TITLE
Add VS Code to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /.yarnrc
 /docker
 /.npmrc
+.vscode
+.vscode/


### PR DESCRIPTION
We ignore both the directory and file since a symlink acts as a file and you might want to symlink a global config directory for all Element related projects