### PR TITLE
Update matrix-org-eslint-plugin and tighten max warning limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "asar-webapp": "asar p webapp webapp.asar",
     "start": "yarn run build:ts && yarn run build:res && electron .",
     "lint": "yarn lint:types && yarn lint:js",
-    "lint:js": "eslint src/ scripts/ hak/",
+    "lint:js": "eslint --max-warnings 0 src scripts hak",
     "lint:js-fix": "eslint --fix src scripts hak",
     "lint:types": "tsc --noEmit",
     "build:native": "yarn run hak",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,8 +1849,8 @@ eslint-config-google@^0.14.0:
   integrity sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==
 
 "eslint-plugin-matrix-org@github:matrix-org/eslint-plugin-matrix-org#main":
-  version "0.3.2"
-  resolved "https://codeload.github.com/matrix-org/eslint-plugin-matrix-org/tar.gz/8529f1d77863db6327cf1a1a4fa65d06cc26f91b"
+  version "0.3.3"
+  resolved "https://codeload.github.com/matrix-org/eslint-plugin-matrix-org/tar.gz/50d6bdf6704dd95016d5f1f824f00cac6eaa64e1"
 
 eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
Whilst it is down, make the most of it!

Notes: none