### PR TITLE
Revert to generic update path for universal builds & switch to new domain

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -1,5 +1,5 @@
 {
-    "update_base_url": "https://packages.riot.im/nightly/update/",
+    "update_base_url": "https://packages.element.io/nightly/update/",
     "default_server_name": "matrix.org",
     "brand": "Element Nightly",
     "integrations_ui_url": "https://scalar.vector.im/",

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -52,7 +52,7 @@ export function start(updateBaseUrl: string): void {
             // rely on NSURLConnection setting the User-Agent to what we expect,
             // and also acts as a convenient cache-buster to ensure that when the
             // app updates it always gets a fresh value to avoid update-looping.
-            url = `${updateBaseUrl}macos/${process.arch}/?localVersion=${encodeURIComponent(app.getVersion())}`;
+            url = `${updateBaseUrl}macos/?localVersion=${encodeURIComponent(app.getVersion())}`;
         } else if (process.platform === 'win32') {
             url = `${updateBaseUrl}win32/${process.arch}/`;
         } else {


### PR DESCRIPTION
Switches back to looking in the arch-less path for mac updates.

Also switches to the new domain.