### PR TITLE
Only set `enable-features` if the user hasn't

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -780,7 +780,9 @@ ipcMain.on('seshat', async function(ev, payload) {
 });
 
 app.commandLine.appendSwitch('--enable-usermedia-screen-capturing');
-app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
+if (!app.commandLine.hasSwitch('enable-features')) {
+    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
+}
 
 const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {


### PR DESCRIPTION
Fix the issue mentioned in my comment in https://github.com/vector-im/element-desktop/pull/256

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->