### PR TITLE
Update to Electron 13.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "allchange": "^1.0.2",
     "asar": "^2.0.1",
     "chokidar": "^3.5.2",
-    "electron": "13",
+    "electron": "13.5",
     "electron-builder": "22.11.4",
     "electron-builder-squirrel-windows": "22.11.4",
     "electron-devtools-installer": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "13.4.0",
+    "electronVersion": "13.5.0",
     "files": [
       "package.json",
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,10 +1955,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@13:
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.4.0.tgz#f9f9e518d8c6bf23bfa8b69580447eea3ca0f880"
-  integrity sha512-KJGWS2qa0xZXIMPMDUNkRVO8/JxRd4+M0ejYYOzu2LIQ5ijecPzNuNR9nvDkml9XyyRBzu975FkhJcwD17ietQ==
+electron@13.5:
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.5.0.tgz#6f746ca55d6be4f20dd4b799a5bf42fcb1ea0587"
+  integrity sha512-s4+b1RFWkNKWp7WWrv2q60MuFljHUCbO7XAupBSCUz/NP1Hz4OenWbMPUt0H+fa8YZeN8CX3JDIA8Bet5uAJvw==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Release notes: https://github.com/electron/electron/releases/tag/v13.5.0

We should be on the latest version of 13.x anyway, but this release may help fix https://github.com/vector-im/element-web/issues/19169 as it includes https://github.com/electron/electron/pull/31091

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->