### PR TITLE
Explain how to turn on labs when using the flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ User-specified config.json
 
 + `%APPDATA%\$NAME\config.json` on Windows
 + `$XDG_CONFIG_HOME\$NAME\config.json` or `~/.config/$NAME/config.json` on Linux
+   + `~/.var/app/im.riot.Riot/config/$NAME/config.json` when using the [community Flatpak](https://flathub.org/apps/details/im.riot.Riot)
 + `~/Library/Application Support/$NAME/config.json` on macOS
 
 In the paths above, `$NAME` is typically `Element`, unless you use `--profile


### PR DESCRIPTION
or "I want the threading preview too, damnit".

Tested manually with 

```
cat ~/.var/app/im.riot.Riot/config/Element/config.json 
{
	"showLabsSettings": true
}
```

on Fedora 35. Initially this file was a symlink pointing outside of the flatpak area. I suspect the app tried to open the link and failed due to flatpak's isolation machinery. I couldn't see anything in stdout to indicate that was the case though---just guessing.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->