### PR TITLE
Put electronVersion back

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   },
   "build": {
     "appId": "im.riot.app",
+    "electronVersion": "13.5.2",
     "files": [
       "package.json",
       {


### PR DESCRIPTION
seems letting electron builder take it from the dependencies confuses
the keytar build process