### PR TITLE
Fix git protocol usage for CI

### DIFF
--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -17,7 +17,7 @@ clone() {
     if [ -n "$branch" ]
     then
         echo "Trying to use $org/$repo#$branch"
-        git clone git://github.com/$org/$repo.git $repo --branch "$branch" --depth 1 && exit 0
+        git clone https://github.com/$org/$repo.git $repo --branch "$branch" --depth 1 && exit 0
     fi
 }
 


### PR DESCRIPTION
Prevents this:
```
+ git clone git://github.com/matrix-org/matrix-js-sdk.git matrix-js-sdk --branch develop --depth 1
Cloning into 'matrix-js-sdk'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->