### PR TITLE
Upgrade docker image to bionic

### DIFF
--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:xenial-curl
+FROM buildpack-deps:bionic-curl
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -10,7 +10,7 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # python for node-gyp
   # rpm is required for FPM to build rpm package
   # libsecret-1-dev and libgnome-keyring-dev are required even for prebuild keytar
-  apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl3 git git-lfs ssh unzip \
+  apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip \
   libsecret-1-dev libgnome-keyring-dev \
   libopenjp2-tools \
   # Used by Seshat


### PR DESCRIPTION
xenial is no longer in LTS, so the docker image just doesn't build
anymore (lacks the letsencrypt ISRG root cert that classic.yarnpkg.com
uses).

Upgrade to the next LTS (bionic).

The libcurl change essentally reverts a change made when changing
back to xenial initially (xenial had curl3 and bionic has 4, so
installing a different libcurl version caused curl itself to be
removed).

Headlines: The Linux build image has been updated to bionic. This version of element will use a newer glibc which will drop support for some older systems.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->