### PR TITLE
Set app name for UISI autorageshakes in element.io configs

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -13,6 +13,7 @@
     ],
     "hosting_signup_link": "https://element.io/matrix-services?utm_source=element-web&utm_medium=web",
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
+    "uisi_autorageshake_app": "element-auto-uisi",
     "showLabsSettings": true,
     "piwik": {
         "url": "https://piwik.riot.im/",

--- a/element.io/release/config.json
+++ b/element.io/release/config.json
@@ -13,6 +13,7 @@
     ],
     "hosting_signup_link": "https://element.io/matrix-services?utm_source=element-web&utm_medium=web",
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
+    "uisi_autorageshake_app": "element-auto-uisi",
     "roomDirectory": {
         "servers": [
             "matrix.org",


### PR DESCRIPTION
This adds a new setting implemented in matrix-org/matrix-react-sdk#7598 to avoid cluttering the main rageshake repo with UISI autorageshakes.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->