### PR TITLE
"Show/Hide" tray action shows window from background instead of hiding it.

### DIFF
--- a/src/tray.ts
+++ b/src/tray.ts
@@ -36,7 +36,7 @@ export function destroy(): void {
 }
 
 function toggleWin(): void {
-    if (global.mainWindow.isVisible() && !global.mainWindow.isMinimized()) {
+    if (global.mainWindow.isVisible() && !global.mainWindow.isMinimized() && global.mainWindow.isFocused()) {
         global.mainWindow.hide();
     } else {
         if (global.mainWindow.isMinimized()) global.mainWindow.restore();


### PR DESCRIPTION
Type: enhancement

# Motivation

I've been using Element as a new user and have encountered some unintuitive behaviour of the system tray icon. When the Element window is open but behind another window, I interact with the system tray in order to bring element into focus. However, because of the toggle action, instead of bringing the Element window into focus, the window is closed in the background. I then need to perform a second interaction with the system tray (2 more clicks) to bring element into focus.

# Specific changes

EDIT: I have changed the behaviour and updated this description, to the behaviour suggested by @t3chguy.

There are three main states for the Element (electron) window:
1. `state 1`: Open and in focus.
2. `state 2`: Open, but minimized or behind another window.
3. `state 3`: Closed

In the existing behaviour, the "Show/Hide" tray action has the following state transitions:
- In focus (`state 1`) -> Closed (`state 3`)
- In background (`state 2`) -> Closed (`state 3`)
- Closed (`state 3`) -> In Focus (`state 1`)

In the new behaviour, the tray action has these state transitions:
- In focus (`state 1`) -> Closed (`state 3`)
- In background (`state 2`) **-> In focus (`state 1`)**
- Closed (`state 3`) -> In focus (`state 1`)

When the Element window is closed, the action has the same effect as before (to open the Element window, and bring it to focus). However, when the Element window is open, either in focus or in the background, the action no longer closes it, and instead brings the window into focus.

# Justification

The new behaviour has superior UX to the old behaviour.

It takes two clicks to interact with the system tray (one to open the menu, one to select the "Show" action). I claim the most common action a user will use the system tray for, is to bring the Element window into focus. However, currently it takes four clicks to bring the window into focus from `state 2`:
- From `state 2`, the current behaviour causes the window to be closed (`state 3`).
- Doing the same action again opens the window to focus (`state 1`).

In the new behaviour, this only takes one action.

One thing the existing behaviour does allow, is closing the element window (in two clicks) while it is still in the background. After this change, this can be done by either:
- Interacting with the tray action again.
- Using the system to close the window after it has been brought to focus (e.g. close button, Alt-F4, etc.)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * "Show/Hide" tray action shows window from background instead of hiding it. ([\#312](https://github.com/vector-im/element-desktop/pull/312)). Contributed by @maxeonyx.<!-- CHANGELOG_PREVIEW_END -->