### PR TITLE
Added Linux aarch64 capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:native:universal": "yarn run hak --target x86_64-apple-darwin fetchandbuild && yarn run hak --target aarch64-apple-darwin fetchandbuild && yarn run hak --target x86_64-apple-darwin --target aarch64-apple-darwin copyandlink",
     "build:32": "yarn run build:ts && yarn run build:res && electron-builder --ia32",
     "build:64": "yarn run build:ts && yarn run build:res && electron-builder --x64",
+    "build:aarch64": "yarn run build:ts && yarn run build:res && USE_SYSTEM_FPM=true electron-builder --arm64",
     "build:universal": "yarn run build:ts && yarn run build:res && electron-builder --universal",
     "build": "yarn run build:ts && yarn run build:res && electron-builder",
     "build:ts": "tsc",

--- a/scripts/hak/target.ts
+++ b/scripts/hak/target.ts
@@ -23,6 +23,7 @@ export type TargetId =
     'universal-apple-darwin' |
     'i686-pc-windows-msvc' |
     'x86_64-pc-windows-msvc' |
+    'aarch64-unknown-linux-gnu' |
     'x86_64-unknown-linux-gnu';
 
 // Values are expected to match those used in `process.platform`.
@@ -87,6 +88,12 @@ const x8664PcWindowsMsvc: WindowsTarget = {
     vcVarsArch: 'amd64',
 };
 
+const aarch64UnknownLinuxGnu: Target = {
+    id: 'aarch64-unknown-linux-gnu',
+    platform: 'linux',
+    arch: 'arm64',
+};
+
 const x8664UnknownLinuxGnu: Target = {
     id: 'x86_64-unknown-linux-gnu',
     platform: 'linux',
@@ -100,6 +107,7 @@ export const TARGETS: Record<TargetId, Target> = {
     'i686-pc-windows-msvc': i686PcWindowsMsvc,
     'x86_64-pc-windows-msvc': x8664PcWindowsMsvc,
     'x86_64-unknown-linux-gnu': x8664UnknownLinuxGnu,
+    'aarch64-unknown-linux-gnu': aarch64UnknownLinuxGnu,
 };
 
 // The set of targets we build by default, sorted by increasing complexity so


### PR DESCRIPTION
I have a Pinebook Pro and I wanted to be able to use Element Desktop on it.

This solution is working at the time of writing with Element Desktop 1.10.3.

I added `build:aarch64` to package.json.
`electron-builder` tries to use its bundled x86 version of `fpm` by default, so the aarch64 builder uses the environment variable `USE_SYSTEM_FPM=true` to override this.

I added the `aarch64-unknown-linux-gnu` target to scripts/hak/target.ts

After making those changes, in Gentoo I ran:
```
sudo gem install fpm
sudo ln -s /usr/local/lib64/ruby/gems/2.7.0/bin/fpm /usr/local/bin/
yarn install
yarn run fetch --importkey
yarn run fetch --noverify --cfgdir ""
yarn run build:native --target aarch64-unknown-linux-gnu
yarn run build:aarch64
```

I didn't find an fpm package in Gentoo's package manager, so I did it a lazy way. I'm sure there's a more elegant way to handle that part.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Added Linux aarch64 capability ([\#323](https://github.com/vector-im/element-desktop/pull/323)). Contributed by @K0HAX.<!-- CHANGELOG_PREVIEW_END -->