### PR TITLE
Build statically-linked sqlcipher for Unix

### DIFF
--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -12,9 +12,7 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # libsecret-1-dev and libgnome-keyring-dev are required even for prebuild keytar
   apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip \
   libsecret-1-dev libgnome-keyring-dev \
-  libopenjp2-tools \
-  # Used by Seshat
-  libsqlcipher-dev && \
+  libopenjp2-tools && \
   # git-lfs
   git lfs install && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*

--- a/element.io/nightly/control.template
+++ b/element.io/nightly/control.template
@@ -3,7 +3,7 @@ License: Apache-2.0
 Vendor: support@element.io
 Architecture: amd64
 Maintainer: support@element.io
-Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0, libsqlcipher0
+Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0
 Recommends: libappindicator3-1
 Section: net
 Priority: extra

--- a/element.io/release/control.template
+++ b/element.io/release/control.template
@@ -3,7 +3,7 @@ License: Apache-2.0
 Vendor: support@element.io
 Architecture: amd64
 Maintainer: support@element.io
-Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0, libsqlcipher0
+Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0
 Recommends: libappindicator3-1
 Replaces: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)
 Breaks: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)

--- a/hak/matrix-seshat/build.ts
+++ b/hak/matrix-seshat/build.ts
@@ -277,6 +277,21 @@ async function buildMatrixSeshat(hakEnv, moduleInfo) {
     });
 
     if (hakEnv.isLinux()) {
+        // Ensure Element uses the statically-linked seshat build, and prevent other applications
+        // from attempting to use this one. Detailed explanation:
+        //
+        // RUSTFLAGS
+        //     An environment variable containing a list of arguments to pass to rustc.
+        // -Clink-arg=VALUE
+        //     A rustc argument to pass a single argument to the linker.
+        // -Wl,
+        //     gcc syntax to pass an argument (from gcc) to the linker (ld).
+        // -Bsymbolic:
+        //     Prefer local/statically linked symbols over those in the environment.
+        //     Prevent overriding native libraries by LD_PRELOAD etc.
+        // --exclude-libs ALL
+        //     Prevent symbols from being exported by any archive libraries.
+        //     Reduces output filesize and prevents being dynamically linked against.
         env.RUSTFLAGS = '-Clink-arg=-Wl,-Bsymbolic -Clink-arg=-Wl,--exclude-libs,ALL';
     }
 

--- a/hak/matrix-seshat/build.ts
+++ b/hak/matrix-seshat/build.ts
@@ -277,7 +277,7 @@ async function buildMatrixSeshat(hakEnv, moduleInfo) {
     });
 
     if (hakEnv.isLinux()) {
-        env.RUSTFLAGS = '-Clink-arg=-Wl,-Bsymbolic -Clink-arg=-Wl,--exclude-libs,ALL'
+        env.RUSTFLAGS = '-Clink-arg=-Wl,-Bsymbolic -Clink-arg=-Wl,--exclude-libs,ALL';
     }
 
     if (hakEnv.isWin()) {

--- a/hak/matrix-seshat/check.ts
+++ b/hak/matrix-seshat/check.ts
@@ -22,21 +22,19 @@ import { DependencyInfo } from '../../scripts/hak/dep';
 
 export default async function(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
     // of course tcl doesn't have a --version
-    if (!hakEnv.isLinux()) {
-        await new Promise<void>((resolve, reject) => {
-            const proc = childProcess.spawn('tclsh', [], {
-                stdio: ['pipe', 'ignore', 'ignore'],
-            });
-            proc.on('exit', (code) => {
-                if (code !== 0) {
-                    reject("Can't find tclsh - have you installed TCL?");
-                } else {
-                    resolve();
-                }
-            });
-            proc.stdin.end();
+    await new Promise<void>((resolve, reject) => {
+        const proc = childProcess.spawn('tclsh', [], {
+            stdio: ['pipe', 'ignore', 'ignore'],
         });
-    }
+        proc.on('exit', (code) => {
+            if (code !== 0) {
+                reject("Can't find tclsh - have you installed TCL?");
+            } else {
+                resolve();
+            }
+        });
+        proc.stdin.end();
+    });
 
     const tools = [
         ['rustc', '--version'],

--- a/hak/matrix-seshat/fetchDeps.ts
+++ b/hak/matrix-seshat/fetchDeps.ts
@@ -25,9 +25,7 @@ import HakEnv from '../../scripts/hak/hakEnv';
 import { DependencyInfo } from '../../scripts/hak/dep';
 
 export default async function(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
-    if (!hakEnv.isLinux()) {
-        await getSqlCipher(hakEnv, moduleInfo);
-    }
+    await getSqlCipher(hakEnv, moduleInfo);
 
     if (hakEnv.isWin()) {
         await getOpenSsl(hakEnv, moduleInfo);


### PR DESCRIPTION
This PR is a direct application of [this patch](https://github.com/archlinux/svntogit-community/commit/7bf5e3ecbe220f8847ee01727590751140964c01) by the Arch Linux community to help fix incompatibilities between sqlcipher and electron 15+. Full context is in https://github.com/vector-im/element-web/issues/20926.

I've just copy/pasted the patch to this PR for easier review, but from what I can see, this changeset is:

* Compiling `sqlcipher.so` on Linux, whereas before we relied on it being provided by a separate distro package.
* Setting the `--enable-tcl=no` configure flag when compiling sqlcipher for Mac and Unix.
* Setting the `--with-pic=yes` configure flag for Linux only.
* Setting `RUSTFLAGS=-Clink-arg=-Wl,-Bsymbolic -Clink-arg=-Wl,--exclude-libs,ALL` for Linux only.
* Running `tclsh` on all platforms (previously Linux was excluded).

The implication is that Linux builds will now receive and use a statically-linked version of sqlite instead of relying on distro packages. It may be worth checking with downstream packagers whether this change is OK.

It should also be ensured that the Element Desktop build machines have the appropriate packages installed to handle this new configuration (`tclsh` is needed now, for instance).

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->