### PR TITLE
Prevent packing of native modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "build": {
     "appId": "im.riot.app",
+    "asarUnpack": "**/*.node",
     "files": [
       "package.json",
       {


### PR DESCRIPTION
Fixes vector-im/element-web#17188

before:
```sh
 * Searching for element-desktop ...
 * Contents of net-im/element-desktop-9999:
/usr
/usr/lib64
/usr/lib64/element-desktop
/usr/lib64/element-desktop/app.asar
/usr/lib64/element-desktop/img
/usr/lib64/element-desktop/img/element.ico
/usr/lib64/element-desktop/img/element.png
/usr/lib64/element-desktop/webapp -> ../../share/element-web
/usr/share
/usr/share/applications
/usr/share/applications/electron-16-element-desktop.desktop
```

after:
```sh
 * Searching for element-desktop ...
 * Contents of net-im/element-desktop-1.10.9:
/usr
/usr/lib64
/usr/lib64/element-desktop
/usr/lib64/element-desktop/app.asar
/usr/lib64/element-desktop/app.asar.unpacked
/usr/lib64/element-desktop/app.asar.unpacked/node_modules
/usr/lib64/element-desktop/app.asar.unpacked/node_modules/keytar
/usr/lib64/element-desktop/app.asar.unpacked/node_modules/keytar/build
/usr/lib64/element-desktop/app.asar.unpacked/node_modules/keytar/build/Release
/usr/lib64/element-desktop/app.asar.unpacked/node_modules/keytar/build/Release/keytar.node
/usr/lib64/element-desktop/app.asar.unpacked/node_modules/matrix-seshat
/usr/lib64/element-desktop/app.asar.unpacked/node_modules/matrix-seshat/native
/usr/lib64/element-desktop/app.asar.unpacked/node_modules/matrix-seshat/native/index.node
/usr/lib64/element-desktop/img
/usr/lib64/element-desktop/img/element.ico
/usr/lib64/element-desktop/img/element.png
/usr/lib64/element-desktop/webapp -> ../../share/element-web
/usr/share
/usr/share/applications
/usr/share/applications/electron-18-element-desktop.desktop

```

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent packing of native modules ([\#337](https://github.com/vector-im/element-desktop/pull/337)). Fixes vector-im/element-web#17188. Contributed by @PF4Public.<!-- CHANGELOG_PREVIEW_END -->