### PR TITLE
Allow loading language files with two part language code

### DIFF
--- a/src/language-helper.ts
+++ b/src/language-helper.ts
@@ -97,13 +97,12 @@ export class AppLocalization {
             locale = "en-EN";
         }
         if (locale.indexOf("-") >= 0) {
-            const langDesc = 1;
-            const partsReq = 2;
-            const part = locale.split("-");
-            if (part.length >= partsReq) {
-                part[langDesc] = part[langDesc].toUpperCase();
+            const localeSubIndex = 1;
+            const parts = locale.split("-");
+            if (parts.length > localeSubIndex) {
+                parts[localeSubIndex] = parts[localeSubIndex].toUpperCase();
             }
-            return part.join("_");
+            return parts.join("_");
         }
         return locale;
     }

--- a/src/language-helper.ts
+++ b/src/language-helper.ts
@@ -92,19 +92,16 @@ export class AppLocalization {
         this.resetLocalizedUI();
     }
 
+    // Format language strings from normalized form to non-normalized form (e.g. en-gb to en_GB)
     private denormalize(locale: string): string {
         if (locale === "en") {
-            locale = "en-EN";
+            locale = "en_EN";
         }
-        if (locale.indexOf("-") >= 0) {
-            const localeSubIndex = 1;
-            const parts = locale.split("-");
-            if (parts.length > localeSubIndex) {
-                parts[localeSubIndex] = parts[localeSubIndex].toUpperCase();
-            }
-            return parts.join("_");
+        const parts = locale.split("-");
+        if (parts.length > 1) {
+            parts[1] = parts[1].toUpperCase();
         }
-        return locale;
+        return parts.join("_");
     }
 
     public fetchTranslationJson(locale: string): Record<string, string> {

--- a/src/language-helper.ts
+++ b/src/language-helper.ts
@@ -92,10 +92,26 @@ export class AppLocalization {
         this.resetLocalizedUI();
     }
 
+    private denormalize(locale: string): string {
+        if (locale === "en") {
+            locale = "en-EN";
+        }
+        if (locale.indexOf("-") >= 0) {
+            const langDesc = 1;
+            const partsReq = 2;
+            const part = locale.split("-");
+            if (part.length >= partsReq) {
+                part[langDesc] = part[langDesc].toUpperCase();
+            }
+            return part.join("_");
+        }
+        return locale;
+    }
+
     public fetchTranslationJson(locale: string): Record<string, string> {
         try {
             console.log("Fetching translation json for locale: " + locale);
-            return require(`./i18n/strings/${locale}.json`);
+            return require(`./i18n/strings/${this.denormalize(locale)}.json`);
         } catch (e) {
             console.log(`Could not fetch translation json for locale: '${locale}'`, e);
             return null;


### PR DESCRIPTION
Change the imported filenames to inlcude underscore in two part language names. https://github.com/vector-im/element-web/issues/19218

Signed-off-by: Timo Piiroinen <timo.piiroinen@unikie.com>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Allow loading language files with two part language code ([\#339](https://github.com/vector-im/element-desktop/pull/339)). Contributed by @TPiUnikie.<!-- CHANGELOG_PREVIEW_END -->