### PR TITLE
Fix macOS and Linux build regressions

### DIFF
--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -9,12 +9,11 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # git ssh for using as docker image on CircleCI
   # python for node-gyp
   # rpm is required for FPM to build rpm package
+  # tclsh is required for building SQLite as part of SQLCipher
   # libsecret-1-dev and libgnome-keyring-dev are required even for prebuild keytar
-  apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip \
+  apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip tcl \
   libsecret-1-dev libgnome-keyring-dev \
   libopenjp2-tools && \
-  # tclsh required for building SQLite as part of SQLCipher
-  tcl && \
   # git-lfs
   git lfs install && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*

--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip \
   libsecret-1-dev libgnome-keyring-dev \
   libopenjp2-tools && \
+  # tclsh required for building SQLite as part of SQLCipher
+  tcl && \
   # git-lfs
   git lfs install && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*

--- a/hak/matrix-seshat/check.ts
+++ b/hak/matrix-seshat/check.ts
@@ -21,6 +21,21 @@ import HakEnv from '../../scripts/hak/hakEnv';
 import { DependencyInfo } from '../../scripts/hak/dep';
 
 export default async function(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
+    // of course tcl doesn't have a --version
+    await new Promise<void>((resolve, reject) => {
+        const proc = childProcess.spawn('tclsh', [], {
+            stdio: ['pipe', 'ignore', 'ignore'],
+        });
+        proc.on('exit', (code) => {
+            if (code !== 0) {
+                reject("Can't find tclsh - have you installed TCL?");
+            } else {
+                resolve();
+            }
+        });
+        proc.stdin.end();
+    });
+
     const tools = [
         ['rustc', '--version'],
         ['python', '--version'], // node-gyp uses python for reasons beyond comprehension

--- a/hak/matrix-seshat/check.ts
+++ b/hak/matrix-seshat/check.ts
@@ -21,21 +21,6 @@ import HakEnv from '../../scripts/hak/hakEnv';
 import { DependencyInfo } from '../../scripts/hak/dep';
 
 export default async function(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
-    // of course tcl doesn't have a --version
-    await new Promise<void>((resolve, reject) => {
-        const proc = childProcess.spawn('tclsh', [], {
-            stdio: ['pipe', 'ignore', 'ignore'],
-        });
-        proc.on('exit', (code) => {
-            if (code !== 0) {
-                reject("Can't find tclsh - have you installed TCL?");
-            } else {
-                resolve();
-            }
-        });
-        proc.stdin.end();
-    });
-
     const tools = [
         ['rustc', '--version'],
         ['python', '--version'], // node-gyp uses python for reasons beyond comprehension

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "rimraf": "^3.0.2",
     "tar": "^6.1.2",
     "ts-node": "^10.4.0",
-    "typescript": "^4.5.3"
+    "typescript": "4.5.5"
   },
   "hakDependencies": {
     "matrix-seshat": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5280,10 +5280,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.5.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Mac builds broke due to joyent/node-verror#86
Linux builds broke due to https://github.com/vector-im/element-desktop/pull/334

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix macOS and Linux build regressions ([\#345](https://github.com/vector-im/element-desktop/pull/345)).<!-- CHANGELOG_PREVIEW_END -->