### PR TITLE
Remove stale release.sh parameter for no-jsdoc

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -2,11 +2,11 @@
 #
 # Script to perform a release of element-desktop.
 #
-# Requires githib-changelog-generator; to install, do 
+# Requires githib-changelog-generator; to install, do
 #   pip install git+https://github.com/matrix-org/github-changelog-generator.git
 
 set -e
 
 cd `dirname $0`
 
-./node_modules/matrix-js-sdk/release.sh -n -z "$@"
+./node_modules/matrix-js-sdk/release.sh -n "$@"


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/2382

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->