### PR TITLE
Revert back to using libsqlcipher0 for Debian & Ubuntu packages of Desktop

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,9 @@ on:
   pull_request: { }
   push:
     branches: [ develop, master ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   windows:
     name: Windows
@@ -65,8 +68,7 @@ jobs:
         include:
           - sqlcipher: system
           - sqlcipher: static
-            env: |
-              SQLCIPHER_STATIC=1
+            static: 1
     name: 'Linux (sqlcipher: ${{ matrix.sqlcipher }})'
     runs-on: ubuntu-latest
     steps:
@@ -98,7 +100,8 @@ jobs:
 
       - name: Build Natives
         run: "yarn build:native"
-        env: ${{ matrix.env }}
+        env:
+          SQLCIPHER_STATIC: ${{ matrix.static }}
 
       - name: Build App
         run: "yarn build --publish never"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,14 @@ jobs:
         run: "yarn build --publish never"
 
   linux:
-    name: Linux
+    strategy:
+      matrix:
+        include:
+          - sqlcipher: system
+          - sqlcipher: static
+            env: |
+              SQLCIPHER_STATIC=1
+    name: 'Linux (sqlcipher: ${{ matrix.sqlcipher }})'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -77,6 +84,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install libsqlcipher-dev
+        if: matrix.sqlcipher == 'system'
+        run: sudo apt-get install -y libsqlcipher-dev
+
       - uses: actions/setup-node@v3
         with:
           cache: "yarn"
@@ -87,6 +98,7 @@ jobs:
 
       - name: Build Natives
         run: "yarn build:native"
+        env: ${{ matrix.env }}
 
       - name: Build App
         run: "yarn build --publish never"

--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip tcl \
   libsecret-1-dev libgnome-keyring-dev \
   libopenjp2-tools \
-  # Used by seshat (when not SQLCIPHER_STATIC)
+  # Used by seshat (when not SQLCIPHER_STATIC) \
+  libsqlcipher-dev && \
   # git-lfs
   git lfs install && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*

--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # libsecret-1-dev and libgnome-keyring-dev are required even for prebuild keytar
   apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip tcl \
   libsecret-1-dev libgnome-keyring-dev \
-  libopenjp2-tools && \
+  libopenjp2-tools \
+  # Used by seshat (when not SQLCIPHER_STATIC)
   # git-lfs
   git lfs install && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*

--- a/docs/native-node-modules.md
+++ b/docs/native-node-modules.md
@@ -47,7 +47,7 @@ using yarn at the root of this project:
 
     yarn add matrix-seshat
 
-You will have to rebuild the native libraries against electron's version of
+You will have to rebuild the native libraries against electron's version
 of node rather than your system node, using the `electron-build-env` tool.
 This is also needed to when pulling in changes to Seshat using `yarn link`.
 
@@ -65,6 +65,17 @@ After this is done the Electron version of Element can be run from the main fold
 as usual using:
 
     yarn start
+
+### Statically linking libsqlcipher
+
+On Windows & macOS we always statically link libsqlcipher for it is not generally available.
+On Linux by default we will use a system package, on debian & ubuntu this is `libsqlcipher0`,
+but this is problematic for some other packages. 
+By including `SQLCIPHER_STATIC=1` in the build environment, the build scripts will statically link sqlcipher,
+note that this will want a `libcrypto1.1` shared library available in the system.
+
+More info can be found at https://github.com/matrix-org/seshat/issues/102
+and https://github.com/vector-im/element-web/issues/20926.
 
 ## Compiling for specific architectures
 

--- a/element.io/nightly/control.template
+++ b/element.io/nightly/control.template
@@ -4,9 +4,9 @@ Vendor: support@element.io
 Architecture: amd64
 Maintainer: support@element.io
 Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0
-Recommends: libappindicator3-1
+Recommends: libappindicator3-1, libsqlcipher0
 Section: net
 Priority: extra
 Homepage: https://element.io/
-Description: 
+Description:
  riot.im A feature-rich client for Matrix.org (nightly unstable build).

--- a/element.io/release/control.template
+++ b/element.io/release/control.template
@@ -4,11 +4,11 @@ Vendor: support@element.io
 Architecture: amd64
 Maintainer: support@element.io
 Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0
-Recommends: libappindicator3-1
+Recommends: libappindicator3-1, libsqlcipher0
 Replaces: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)
 Breaks: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)
 Section: net
 Priority: extra
 Homepage: https://element.io/
-Description: 
+Description:
   A feature-rich client for Matrix.org

--- a/hak/matrix-seshat/check.ts
+++ b/hak/matrix-seshat/check.ts
@@ -21,20 +21,22 @@ import HakEnv from '../../scripts/hak/hakEnv';
 import { DependencyInfo } from '../../scripts/hak/dep';
 
 export default async function(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
-    // of course tcl doesn't have a --version
-    await new Promise<void>((resolve, reject) => {
-        const proc = childProcess.spawn('tclsh', [], {
-            stdio: ['pipe', 'ignore', 'ignore'],
+    if (hakEnv.wantsStaticSqlCipher()) {
+        // of course tcl doesn't have a --version
+        await new Promise<void>((resolve, reject) => {
+            const proc = childProcess.spawn('tclsh', [], {
+                stdio: ['pipe', 'ignore', 'ignore'],
+            });
+            proc.on('exit', (code) => {
+                if (code !== 0) {
+                    reject("Can't find tclsh - have you installed TCL?");
+                } else {
+                    resolve();
+                }
+            });
+            proc.stdin.end();
         });
-        proc.on('exit', (code) => {
-            if (code !== 0) {
-                reject("Can't find tclsh - have you installed TCL?");
-            } else {
-                resolve();
-            }
-        });
-        proc.stdin.end();
-    });
+    }
 
     const tools = [
         ['rustc', '--version'],

--- a/hak/matrix-seshat/fetchDeps.ts
+++ b/hak/matrix-seshat/fetchDeps.ts
@@ -25,7 +25,9 @@ import HakEnv from '../../scripts/hak/hakEnv';
 import { DependencyInfo } from '../../scripts/hak/dep';
 
 export default async function(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
-    await getSqlCipher(hakEnv, moduleInfo);
+    if (hakEnv.wantsStaticSqlCipher()) {
+        await getSqlCipher(hakEnv, moduleInfo);
+    }
 
     if (hakEnv.isWin()) {
         await getOpenSsl(hakEnv, moduleInfo);
@@ -36,7 +38,7 @@ async function getSqlCipher(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise
     const version = moduleInfo.cfg.dependencies.sqlcipher;
     const sqlCipherDir = path.join(moduleInfo.moduleTargetDotHakDir, `sqlcipher-${version}`);
 
-    let haveSqlcipher;
+    let haveSqlcipher: boolean;
     try {
         await fsProm.stat(sqlCipherDir);
         haveSqlcipher = true;
@@ -47,7 +49,7 @@ async function getSqlCipher(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise
     if (haveSqlcipher) return;
 
     const sqlCipherTarball = path.join(moduleInfo.moduleDotHakDir, `sqlcipher-${version}.tar.gz`);
-    let haveSqlcipherTar;
+    let haveSqlcipherTar: boolean;
     try {
         await fsProm.stat(sqlCipherTarball);
         haveSqlcipherTar = true;
@@ -97,7 +99,7 @@ async function getOpenSsl(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<v
     const version = moduleInfo.cfg.dependencies.openssl;
     const openSslDir = path.join(moduleInfo.moduleTargetDotHakDir, `openssl-${version}`);
 
-    let haveOpenSsl;
+    let haveOpenSsl: boolean;
     try {
         await fsProm.stat(openSslDir);
         haveOpenSsl = true;
@@ -108,7 +110,7 @@ async function getOpenSsl(hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<v
     if (haveOpenSsl) return;
 
     const openSslTarball = path.join(moduleInfo.moduleDotHakDir, `openssl-${version}.tar.gz`);
-    let haveOpenSslTar;
+    let haveOpenSslTar: boolean;
     try {
         await fsProm.stat(openSslTarball);
         haveOpenSslTar = true;

--- a/scripts/hak/hakEnv.ts
+++ b/scripts/hak/hakEnv.ts
@@ -114,4 +114,12 @@ export default class HakEnv {
     getNodeModuleBin(name: string): string {
         return path.join(this.projectRoot, 'node_modules', '.bin', name);
     }
+
+    wantsStaticSqlCipherUnix(): boolean {
+        return this.isMac() || process.env.SQLCIPHER_STATIC == '1';
+    }
+
+    wantsStaticSqlCipher(): boolean {
+        return this.isWin() || this.wantsStaticSqlCipherUnix();
+    }
 }

--- a/scripts/hak/hakEnv.ts
+++ b/scripts/hak/hakEnv.ts
@@ -54,12 +54,12 @@ export default class HakEnv {
         this.dotHakDir = path.join(this.projectRoot, '.hak');
     }
 
-    async init() {
+    public async init() {
         this.runtime = await getRuntime(this.projectRoot);
         this.runtimeVersion = await getRuntimeVersion(this.projectRoot);
     }
 
-    getRuntimeAbi(): string {
+    public getRuntimeAbi(): string {
         return nodePreGypVersioning.get_runtime_abi(
             this.runtime,
             this.runtimeVersion,
@@ -67,35 +67,35 @@ export default class HakEnv {
     }
 
     // {node_abi}-{platform}-{arch}
-    getNodeTriple(): string {
+    public getNodeTriple(): string {
         return this.getRuntimeAbi() + '-' + this.target.platform + '-' + this.target.arch;
     }
 
-    getTargetId(): TargetId {
+    public getTargetId(): TargetId {
         return this.target.id;
     }
 
-    isWin(): boolean {
+    public isWin(): boolean {
         return this.target.platform === 'win32';
     }
 
-    isMac(): boolean {
+    public isMac(): boolean {
         return this.target.platform === 'darwin';
     }
 
-    isLinux(): boolean {
+    public isLinux(): boolean {
         return this.target.platform === 'linux';
     }
 
-    getTargetArch(): Arch {
+    public getTargetArch(): Arch {
         return this.target.arch;
     }
 
-    isHost(): boolean {
+    public isHost(): boolean {
         return isHostId(this.target.id);
     }
 
-    makeGypEnv(): Record<string, string> {
+    public makeGypEnv(): Record<string, string> {
         return Object.assign({}, process.env, {
             npm_config_arch: this.target.arch,
             npm_config_target_arch: this.target.arch,
@@ -107,15 +107,15 @@ export default class HakEnv {
         });
     }
 
-    getNodeModuleBin(name: string): string {
+    public getNodeModuleBin(name: string): string {
         return path.join(this.projectRoot, 'node_modules', '.bin', name);
     }
 
-    wantsStaticSqlCipherUnix(): boolean {
+    public wantsStaticSqlCipherUnix(): boolean {
         return this.isMac() || process.env.SQLCIPHER_STATIC == '1';
     }
 
-    wantsStaticSqlCipher(): boolean {
+    public wantsStaticSqlCipher(): boolean {
         return this.isWin() || this.wantsStaticSqlCipherUnix();
     }
 }


### PR DESCRIPTION
Add option to static link for linux instead of forcing it

Related https://github.com/matrix-org/seshat/issues/102
Related https://github.com/vector-im/element-desktop/pull/334
Related https://github.com/sqlcipher/sqlcipher/issues/385

Fixes https://github.com/vector-im/element-web/issues/22325

Statically linking SQLCipher as we were before breaks Seshat on Ubuntu 22.04 which does not include libssl1.1 - we want to avoid statically linking openssl as it is controversial in some linux packages, and we should be able to get away by going back to relying on a system libsqlcipher0 package to provide sqlcipher for official release packages which were not reported to experience the same gtk related sqlite linking problem as the Arch package had 

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert back to using libsqlcipher0 for Debian & Ubuntu packages of Desktop ([\#367](https://github.com/vector-im/element-desktop/pull/367)). Fixes vector-im/element-web#22325.<!-- CHANGELOG_PREVIEW_END -->