### PR TITLE
Fix default file name in save-image-as

### DIFF
--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -143,7 +143,7 @@ function onLinkContextMenu(ev: Event, params: ContextMenuParams, webContents: We
             label: _t('Save image as...'),
             accelerator: 's',
             async click() {
-                const targetFileName = params.titleText || "image.png";
+                const targetFileName = params.suggestedFilename || params.altText || "image.png";
                 const { filePath } = await dialog.showSaveDialog({
                     defaultPath: targetFileName,
                 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20838

https://github.com/whatwg/html/issues/2722 will be useful here in the future

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix default file name in save-image-as ([\#385](https://github.com/vector-im/element-desktop/pull/385)). Fixes vector-im/element-web#20838.<!-- CHANGELOG_PREVIEW_END -->