### PR TITLE
Don't check for updates if we already have one downloaded and queued

### DIFF
--- a/src/updater.ts
+++ b/src/updater.ts
@@ -28,7 +28,20 @@ function installUpdate(): void {
 
 function pollForUpdates(): void {
     try {
-        autoUpdater.checkForUpdates();
+        // If we've already got a new update downloaded, then stop
+        // trying to check for new ones, as according to the doc
+        // at https://github.com/electron/electron/blob/main/docs/api/auto-updater.md#autoupdatercheckforupdates
+        // we'll just keep re-downloading the same update.
+        // As a hunch, this might also be causing
+        // https://github.com/vector-im/element-web/issues/12433
+        // due to the update checks colliding with the pending install
+        // somehow
+        if (!latestUpdateDownloaded) {
+            autoUpdater.checkForUpdates();
+        }
+        else {
+            console.log("Skipping update check as download already present");
+        }
     } catch (e) {
         console.log('Couldn\'t check for update', e);
     }

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -38,8 +38,7 @@ function pollForUpdates(): void {
         // somehow
         if (!latestUpdateDownloaded) {
             autoUpdater.checkForUpdates();
-        }
-        else {
+        } else {
             console.log("Skipping update check as download already present");
         }
     } catch (e) {


### PR DESCRIPTION
This is a punt at fixing https://github.com/vector-im/element-web/issues/12433,
on the assumption that multiple update checks might collide with a
download which are already queued to install.  It also avoids repeatedly
re-downloading the same update on every check, as per the Note: on
https://github.com/electron/electron/blob/main/docs/api/auto-updater.md#autoupdatercheckforupdates

However, it means that you may have to upgrade twice if you wait more than 24h to install
a new build (once for the old build, and once for the latest build)- and if you cancel an upgrade prompt,
you'll have to either restart the app or explicitly check for a new version to get upgrades working again.
However, this is less annoying than having the app fail to relaunch after upgrading.
The double-install (mis)behaviour also seems to exist today.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't check for updates if we already have one downloaded and queued ([\#386](https://github.com/vector-im/element-desktop/pull/386)).<!-- CHANGELOG_PREVIEW_END -->
