### PR TITLE
Retroactively add security fix notice to the changelog of 1.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1108,6 +1108,7 @@ Changes in [1.9.7](https://github.com/vector-im/element-desktop/releases/tag/v1.
 ## 🔒 SECURITY FIXES
 * Security release with updated version of Olm to fix https://matrix.org/blog/2021/12/03/pre-disclosure-upcoming-security-release-of-libolm-and-matrix-js-sdk
 * Upgrade Electron to 13.5.2 to fix https://matrix.org/blog/2022/01/31/high-severity-vulnerability-in-element-desktop-1-9-6-and-earlier (https://github.com/vector-im/element-desktop/security/advisories/GHSA-mjrg-9f8r-h3m7)
+
 ## 🐛 Bug Fixes
 * Fix a crash on logout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1105,8 +1105,11 @@ Changes in [1.9.8](https://github.com/vector-im/element-desktop/releases/tag/v1.
 Changes in [1.9.7](https://github.com/vector-im/element-desktop/releases/tag/v1.9.7) (2021-12-13)
 =================================================================================================
 
- * Security release with updated version of Olm to fix https://matrix.org/blog/2021/12/03/pre-disclosure-upcoming-security-release-of-libolm-and-matrix-js-sdk
- * Fix a crash on logout
+## 🔒 SECURITY FIXES
+* Security release with updated version of Olm to fix https://matrix.org/blog/2021/12/03/pre-disclosure-upcoming-security-release-of-libolm-and-matrix-js-sdk
+* Upgrade Electron to 13.5.2 to fix https://matrix.org/blog/2022/01/31/high-severity-vulnerability-in-element-desktop-1-9-6-and-earlier (https://github.com/vector-im/element-desktop/security/advisories/GHSA-mjrg-9f8r-h3m7)
+## 🐛 Bug Fixes
+* Fix a crash on logout
 
 Changes in [1.9.6](https://github.com/vector-im/element-desktop/releases/tag/v1.9.6) (2021-12-06)
 =================================================================================================


### PR DESCRIPTION
To mention the fix for https://matrix.org/blog/2022/01/31/high-severity-vulnerability-in-element-desktop-1-9-6-and-earlier.

Signed-off-by: Denis Kasak <dkasak@termina.org.uk>

## Checklist

* [x] Ensure your code works with manual testing
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->