### PR TITLE
Update to Electron 21

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "babel-jest": "^28.1.3",
     "chokidar": "^3.5.2",
     "detect-libc": "^1.0.3",
-    "electron": "^20",
+    "electron": "^21",
     "electron-builder": "^23.6.0",
     "electron-builder-squirrel-windows": "^23.6.0",
     "electron-devtools-installer": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,10 +3322,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@^20:
-  version "20.3.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-20.3.5.tgz#4512736c96338215855794d0e8010563a873d126"
-  integrity sha512-xTBjdgAZXf6txxfIhv9mZ3yloJZ+KTht7D2X10uHlFnQu4ZmvzqwhGuQPnldVKhRUDvZehIjulmmrFO6Mz6SzQ==
+electron@^21:
+  version "21.3.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-21.3.0.tgz#e9905e240add950443dc115b4be13d36162f0a05"
+  integrity sha512-MGRpshN8fBcx4IRuBABIsGDv0tB/MclIFsyFHFFXsBCUc+vIXaE/E6vuWaniGIFSz5WyeuapfTH5IeRb+7yIfw==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23783

# Stack Upgrades
Chromium 106.0.5249.51
[New in 106](https://developer.chrome.com/blog/new-in-chrome-106)
[New in 105](https://developer.chrome.com/blog/new-in-chrome-105/)
Node v16.16.0
[v16.16.0 release notes](https://nodejs.org/en/blog/release/v16.16.0/)
V8 v10.6

# Breaking Changes
Enabled the V8 memory cage for external buffers. See https://www.electronjs.org/blog/v8-memory-cage for more details. https://github.com/electron/electron/pull/34724
Refactored webContents.printToPDF to align with the Chrome Devtools implementation. https://github.com/electron/electron/pull/33654

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Update to Electron 21 ([\#458](https://github.com/vector-im/element-desktop/pull/458)).<!-- CHANGELOG_PREVIEW_END -->