### PR TITLE
Set StartupWMClass correctly for nightly builds

### DIFF
--- a/scripts/generate-builder-config.ts
+++ b/scripts/generate-builder-config.ts
@@ -93,6 +93,7 @@ async function main(): Promise<number | void> {
 
     if (argv.nightly) {
         cfg.appId = NIGHTLY_APP_ID;
+        cfg.linux.desktop.StartupWMClass += "-nightly";
         cfg.extraMetadata!.productName += " Nightly";
         cfg.extraMetadata!.name = NIGHTLY_APP_NAME;
 


### PR DESCRIPTION
Blocked on https://github.com/vector-im/element-builder/pull/86 being tested