### PR TITLE
Update to Electron 22.2.0 - fix tray icons in Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-jest": "^29.0.0",
     "chokidar": "^3.5.2",
     "detect-libc": "^1.0.3",
-    "electron": "^22.0.0",
+    "electron": "^22.2.0",
     "electron-builder": "^23.6.0",
     "electron-builder-squirrel-windows": "^23.6.0",
     "electron-devtools-installer": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4371,10 +4371,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@^22.0.0:
-  version "22.0.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-22.0.2.tgz#256c3f7749bcab5d68dc0ba4ae86c1b60852f0b3"
-  integrity sha512-NdJlA2+FMgDJBhQFKMPyWJY8ng/tWpFlrRsW2JkZgSzYPXOnIu9muO3b83YHGoDn+GTyS8ghPsgcAwPMXtxirA==
+electron@^22.2.0:
+  version "22.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-22.2.0.tgz#1aa321415d8b8021a4b0807641f0ad56028feaf5"
+  integrity sha512-puRZSF2vWJ4pz3oetL5Td8LcuivTWz3MoAk/gjImHSN1B/2VJNEQlw1jGdkte+ppid2craOswE2lmCOZ7SwF1g==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23993
Through https://github.com/electron/electron/issues/36602

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Update to Electron 22.2.0 - fix tray icons in Linux ([\#530](https://github.com/vector-im/element-desktop/pull/530)). Fixes vector-im/element-web#23993.<!-- CHANGELOG_PREVIEW_END -->