### PR TITLE
No more ehome config

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -11,7 +11,6 @@
         "https://scalar-staging.vector.im/api",
         "https://scalar-staging.riot.im/scalar/api"
     ],
-    "hosting_signup_link": "https://element.io/matrix-services?utm_source=element-web&utm_medium=web",
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
     "uisi_autorageshake_app": "element-auto-uisi",
     "showLabsSettings": true,

--- a/element.io/release/config.json
+++ b/element.io/release/config.json
@@ -11,7 +11,6 @@
         "https://scalar-staging.vector.im/api",
         "https://scalar-staging.riot.im/scalar/api"
     ],
-    "hosting_signup_link": "https://element.io/matrix-services?utm_source=element-web&utm_medium=web",
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
     "uisi_autorageshake_app": "element-auto-uisi",
     "roomDirectory": {


### PR DESCRIPTION
Same as https://github.com/vector-im/element-web/pull/24542, for desktop.

Notes: Remove ad for Element Home

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->