### PR TITLE
Iterate ARM support in CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -92,7 +92,7 @@ jobs:
               if: matrix.prepare_cmd
 
             - name: Run tests
-              uses: GabrielBB/xvfb-action@v1
+              uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
               timeout-minutes: 5
               with:
                   run: "yarn test"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/workflows/build_windows.yaml
         strategy:
             matrix:
-                arch: [x64, x86, arm64]
+                arch: [x64, x86]
         with:
             arch: ${{ matrix.arch }}
 

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -38,6 +38,7 @@ jobs:
               if: steps.cache.outputs.cache-hit != 'true'
               uses: actions-rs/toolchain@v1
               with:
+                  default: true
                   toolchain: stable
 
             - name: Install libsqlcipher-dev

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -54,6 +54,7 @@ jobs:
               if: steps.cache.outputs.cache-hit != 'true'
               uses: actions-rs/toolchain@v1
               with:
+                  default: true
                   toolchain: stable
                   target: aarch64-apple-darwin
 

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -68,7 +68,7 @@ jobs:
               id: cache
               uses: actions/cache@v3
               with:
-                  key: ${{ runner.os }}-${{ hashFiles('hakDependencies.json', 'electronVersion') }}
+                  key: ${{ runner.os }}-${{ inputs.arch }}-${{ hashFiles('hakDependencies.json', 'electronVersion') }}
                   path: |
                       ./.hak
 
@@ -97,6 +97,7 @@ jobs:
               if: steps.cache.outputs.cache-hit != 'true'
               uses: actions-rs/toolchain@v1
               with:
+                  default: true
                   toolchain: stable
                   target: ${{ steps.config.outputs.target }}
 

--- a/hak/matrix-seshat/build.ts
+++ b/hak/matrix-seshat/build.ts
@@ -22,6 +22,15 @@ import fsExtra from "fs-extra";
 import HakEnv from "../../scripts/hak/hakEnv";
 import { DependencyInfo } from "../../scripts/hak/dep";
 
+type WinConfiguration =
+    | "VC-WIN32"
+    | "VC-WIN64A"
+    | "VC-WIN64-ARM"
+    | "VC-WIN64-CLANGASM-ARM"
+    | "VC-CLANG-WIN64-CLANGASM-ARM"
+    | "VC-WIN32-HYBRIDCRT"
+    | "VC-WIN64A-HYBRIDCRT";
+
 export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
     if (hakEnv.isWin()) {
         await buildOpenSslWin(hakEnv, moduleInfo);
@@ -36,7 +45,18 @@ async function buildOpenSslWin(hakEnv: HakEnv, moduleInfo: DependencyInfo): Prom
     const version = moduleInfo.cfg.dependencies.openssl;
     const openSslDir = path.join(moduleInfo.moduleTargetDotHakDir, `openssl-${version}`);
 
-    const openSslArch = hakEnv.getTargetArch() === "x64" ? "VC-WIN64A" : "VC-WIN32";
+    let openSslArch: WinConfiguration;
+    switch (hakEnv.getTargetArch()) {
+        case "x64":
+            openSslArch = "VC-WIN64A";
+            break;
+        case "ia32":
+            openSslArch = "VC-WIN32";
+            break;
+        case "arm64":
+            openSslArch = "VC-WIN64-ARM";
+            break;
+    }
 
     console.log("Building openssl in " + openSslDir);
     await new Promise<void>((resolve, reject) => {

--- a/scripts/hak/target.ts
+++ b/scripts/hak/target.ts
@@ -100,10 +100,10 @@ const x8664PcWindowsMsvc: WindowsTarget = {
 };
 
 const aarch64WindowsMsvc: WindowsTarget = {
-    id: 'aarch64-pc-windows-msvc',
-    platform: 'win32',
-    arch: 'arm64',
-    vcVarsArch: 'arm64',
+    id: "aarch64-pc-windows-msvc",
+    platform: "win32",
+    arch: "arm64",
+    vcVarsArch: "arm64",
 };
 
 const x8664UnknownLinuxGnu: LinuxTarget = {
@@ -170,7 +170,7 @@ export const TARGETS: Record<TargetId, Target> = {
     // Windows
     "i686-pc-windows-msvc": i686PcWindowsMsvc,
     "x86_64-pc-windows-msvc": x8664PcWindowsMsvc,
-    'aarch64-pc-windows-msvc': aarch64WindowsMsvc,
+    "aarch64-pc-windows-msvc": aarch64WindowsMsvc,
     // Linux
     "i686-unknown-linux-musl": i686UnknownLinuxMusl,
     "i686-unknown-linux-gnu": i686UnknownLinuxGnu,


### PR DESCRIPTION
Split out from https://github.com/vector-im/element-desktop/pull/446

Disables arm64 Windows builds as it turns out they were including x86_64 Seshat and Keytar binaries, arm64 cross-compiling is proving problematic and has been left as an exercise for https://github.com/vector-im/element-desktop/pull/446

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->