### PR TITLE
Run build_linux in docker using an older glibc

### DIFF
--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -39,17 +39,6 @@ jobs:
                   path: |
                       ./.hak
 
-            - name: Install Rust
-              if: steps.cache.outputs.cache-hit != 'true'
-              uses: actions-rs/toolchain@v1
-              with:
-                  default: true
-                  toolchain: stable
-
-            - name: Install libsqlcipher-dev
-              if: steps.cache.outputs.cache-hit != 'true' && inputs.sqlcipher == 'system'
-              run: sudo apt-get install -y libsqlcipher-dev
-
             - uses: actions/setup-node@v3
               with:
                   cache: "yarn"

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -19,6 +19,11 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/vector-im/element-desktop-dockerbuild:t3chguy-dockerbuild
+        defaults:
+            run:
+                shell: bash
         steps:
             - uses: actions/checkout@v3
 
@@ -71,7 +76,7 @@ jobs:
                   if [ -f changelog.Debian ]; then
                       echo "config-args=--deb-changelog changelog.Debian" >> $GITHUB_OUTPUT
                   fi
-                  
+
                   cp "$DIR/control.template" debcontrol
                   VERSION=${INPUT_VERSION:-$(cat package.json | jq -r .version)}
                   echo "Version: $VERSION" >> debcontrol

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -75,7 +75,7 @@ jobs:
 
             - name: Build App
               run: |
-                  scripts/generate-builder-config.ts \
+                  npx ts-node scripts/generate-builder-config.ts \
                       ${{ steps.nightly.outputs.config-args }} \
                       ${{ steps.debian.outputs.config-args }} \
                       --deb-custom-control=debcontrol

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -21,6 +21,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: ghcr.io/vector-im/element-desktop-dockerbuild:t3chguy-dockerbuild
+            volumes:
+                - "/usr/local/share/.cache/yarn/v6:/usr/local/share/.cache/yarn/v6"
+                - "${{ github.workspace }}/.hak:${{ github.workspace }}/.hak"
         defaults:
             run:
                 shell: bash

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -21,9 +21,6 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: ghcr.io/vector-im/element-desktop-dockerbuild:t3chguy-dockerbuild
-            volumes:
-                - "/usr/local/share/.cache/yarn/v6:/usr/local/share/.cache/yarn/v6"
-                - "${{ github.workspace }}/.hak:${{ github.workspace }}/.hak"
         defaults:
             run:
                 shell: bash
@@ -45,6 +42,9 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   cache: "yarn"
+              env:
+                  # Workaround for https://github.com/actions/setup-node/issues/317
+                  FORCE_COLOR: 0
 
             # Does not need branch matching as only analyses this layer
             - name: Install Deps


### PR DESCRIPTION
Requires https://github.com/vector-im/element-desktop/pull/598
Fixes https://github.com/vector-im/element-web/issues/24981

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Run build_linux in docker using an older glibc ([\#599](https://github.com/vector-im/element-desktop/pull/599)). Fixes vector-im/element-web#24981.<!-- CHANGELOG_PREVIEW_END -->