### PR TITLE
Fix missing symbols in static sqlcipher aarch64 build

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -79,11 +79,6 @@ jobs:
             matrix:
                 sqlcipher: [system, static]
                 arch: [amd64, arm64]
-                exclude:
-                    # FIXME: This combination yields a broken Seshat at this time
-                    # Errors at launch with `undefined symbol: PKCS5_PBKDF2_HMAC
-                    - arch: arm64
-                      sqlcipher: static
         with:
             config: ${{ github.event.pull_request.base.ref == 'develop' && 'element.io/nightly' || 'element.io/release' }}
             sqlcipher: ${{ matrix.sqlcipher }}

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -84,6 +84,7 @@ jobs:
               if: inputs.sqlcipher == 'static'
               run: |
                   echo "SQLCIPHER_STATIC=1" >> $GITHUB_ENV
+                  echo "LDFLAGS=-lcrypto" >> $GITHUB_ENV
 
             # Ideally the docker image would be ready for cross-compilation but libsqlcipher-dev is not Multi-Arch compatible
             # https://unix.stackexchange.com/a/349359

--- a/dockerbuild/aarch64/.env
+++ b/dockerbuild/aarch64/.env
@@ -8,4 +8,3 @@ LD=/usr/bin/aarch64-linux-gnu-ld
 FC=/usr/bin/aarch64-linux-gnu-gfortran
 PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
 CFLAGS=-L/usr/lib/aarch64-linux-gnu
-RUSTFLAGS=-L/usr/lib/aarch64-linux-gnu

--- a/hak/matrix-seshat/build.ts
+++ b/hak/matrix-seshat/build.ts
@@ -222,8 +222,8 @@ async function buildSqlCipherUnix(hakEnv: HakEnv, moduleInfo: DependencyInfo): P
         ldflags.push("-framework Foundation");
     }
 
+    if (process.env.LDFLAGS) ldflags.unshift(process.env.LDFLAGS);
     if (ldflags.length) {
-        if (process.env.LDFLAGS) ldflags.unshift(process.env.LDFLAGS);
         args.push(`LDFLAGS=${ldflags.join(" ")}`);
     }
 


### PR DESCRIPTION
Requires https://github.com/vector-im/element-desktop/pull/446

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Fix missing symbols in static sqlcipher aarch64 build ([\#628](https://github.com/vector-im/element-desktop/pull/628)).<!-- CHANGELOG_PREVIEW_END -->