### PR TITLE
Update to seshat 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "typescript": "5.0.4"
     },
     "hakDependencies": {
-        "matrix-seshat": "^3.0.0",
+        "matrix-seshat": "^3.0.1",
         "keytar": "^7.9.0"
     },
     "resolutions": {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-desktop/issues/959

Hak dependencies don't have lockfiles so `^` specifiers don't *really* work

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Update to seshat 3.0.1 ([\#960](https://github.com/vector-im/element-desktop/pull/960)). Fixes #959.<!-- CHANGELOG_PREVIEW_END -->