### PR TITLE
Point Nightly to our Element Call + LiveKit experiment

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -45,7 +45,7 @@
         "feature_video_rooms": true
     },
     "element_call": {
-        "url": "https://element-call.netlify.app"
+        "url": "https://element-call-livekit.netlify.app"
     },
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
 }


### PR DESCRIPTION
This is an experimental version of Element Call using a LiveKit SFU that we'd like to start dogfooding and gaining confidence on internally, so the current plan is to trial it on develop.element.io and Nightly for a while.

Depends on https://github.com/vector-im/element-call/pull/1127
See also https://github.com/vector-im/element-web/pull/25636

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->