### PR TITLE
Add fallback `default_server_config` to element.io configs

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -1,6 +1,14 @@
 {
     "update_base_url": "https://packages.element.io/nightly/update/",
     "default_server_name": "matrix.org",
+    "default_server_config": {
+        "m.homeserver": {
+            "base_url": "https://matrix-client.matrix.org"
+        },
+        "m.identity_server": {
+            "base_url": "https://vector.im"
+        }
+    },
     "brand": "Element Nightly",
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",

--- a/element.io/release/config.json
+++ b/element.io/release/config.json
@@ -1,6 +1,14 @@
 {
     "update_base_url": "https://packages.element.io/desktop/update/",
     "default_server_name": "matrix.org",
+    "default_server_config": {
+        "m.homeserver": {
+            "base_url": "https://matrix-client.matrix.org"
+        },
+        "m.identity_server": {
+            "base_url": "https://vector.im"
+        }
+    },
     "brand": "Element",
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",


### PR DESCRIPTION
See https://github.com/vector-im/element-web/pull/19695

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->