### PR TITLE
Fix Tray icon in Windows forgetting your settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
         "electron-window-state": "^5.0.3",
         "minimist": "^1.2.6",
         "node-fetch": "^2",
-        "png-to-ico": "^2.1.1"
+        "png-to-ico": "^2.1.1",
+        "uuid": "^9.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -81,6 +82,7 @@
         "@types/node": "16.18.37",
         "@types/pacote": "^11.1.1",
         "@types/tar": "^6.1.3",
+        "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^5.42.0",
         "@typescript-eslint/parser": "^5.42.0",
         "allchange": "^1.0.6",

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -19,6 +19,7 @@ import { app, Tray, Menu, nativeImage } from "electron";
 import pngToIco from "png-to-ico";
 import path from "path";
 import fs from "fs";
+import { v5 as uuidv5 } from "uuid";
 
 import { _t } from "./language-helper";
 
@@ -50,12 +51,28 @@ interface IConfig {
     brand: string;
 }
 
+function getUuid(): string {
+    // The uuid field is optional and only needed on unsigned Windows packages where the executable path changes
+    // The hardcoded uuid is an arbitrary v4 uuid generated on https://www.uuidgenerator.net/version4
+    return global.vectorConfig["uuid"] || "eba84003-e499-4563-8e9d-166e34b5cc25";
+}
+
 export function create(config: IConfig): void {
     // no trays on darwin
     if (process.platform === "darwin" || trayIcon) return;
     const defaultIcon = nativeImage.createFromPath(config.icon_path);
 
-    trayIcon = new Tray(defaultIcon);
+    let guid: string | undefined;
+    if (process.platform === "win32" && app.isPackaged) {
+        // Providing a GUID lets Windows be smarter about maintaining user's tray preferences
+        // https://github.com/electron/electron/pull/21891
+        // Ideally we would only specify it for signed packages but determining whether the app is signed sufficiently
+        // is non-trivial. So instead we have an escape hatch that unsigned packages can iterate the `uuid` in
+        // config.json to prevent Windows refusing GUID-reuse if their executable path changes.
+        guid = uuidv5(`${app.getName()}-${app.getPath("userData")}`, getUuid());
+    }
+
+    trayIcon = new Tray(defaultIcon, guid);
     trayIcon.setToolTip(config.brand);
     initApplicationMenu();
     trayIcon.on("click", toggleWin);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,6 +2183,11 @@
     "@types/node" "*"
     minipass "^4.0.0"
 
+"@types/uuid@^9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.2.tgz#ede1d1b1e451548d44919dc226253e32a6952c4b"
+  integrity sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==
+
 "@types/verror@^1.10.3":
   version "1.10.6"
   resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.6.tgz#3e600c62d210c5826460858f84bcbb65805460bb"
@@ -7754,6 +7759,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
By passing guid to Tray creation in windows

Fixes https://github.com/vector-im/element-desktop/issues/786

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Fix Tray icon in Windows forgetting your settings ([\#1059](https://github.com/vector-im/element-desktop/pull/1059)). Fixes #786.<!-- CHANGELOG_PREVIEW_END -->