### PR TITLE
Switch to the new `session` API for screen-sharing

### DIFF
--- a/src/displayMediaCallback.ts
+++ b/src/displayMediaCallback.ts
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Streams } from "electron";
+
+type DisplayMediaCallback = (streams: Streams) => void;
+
+let displayMediaCallback: DisplayMediaCallback | null;
+
+export const getDisplayMediaCallback = (): DisplayMediaCallback | null => {
+    return displayMediaCallback;
+};
+
+export const setDisplayMediaCallback = (callback: DisplayMediaCallback | null): void => {
+    displayMediaCallback = callback;
+};

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -19,7 +19,7 @@ limitations under the License.
 
 // Squirrel on windows starts the app with various flags as hooks to tell us when we've been installed/uninstalled etc.
 import "./squirrelhooks";
-import { app, BrowserWindow, Menu, autoUpdater, protocol, dialog, Input, Event } from "electron";
+import { app, BrowserWindow, Menu, autoUpdater, protocol, dialog, Input, Event, session } from "electron";
 import * as Sentry from "@sentry/electron/main";
 import AutoLaunch from "auto-launch";
 import path from "path";
@@ -39,6 +39,7 @@ import webContentsHandler from "./webcontents-handler";
 import * as updater from "./updater";
 import { getProfileFromDeeplink, protocolInit } from "./protocol";
 import { _t, AppLocalization } from "./language-helper";
+import { setDisplayMediaCallback } from "./displayMediaCallback";
 
 const argv = minimist(process.argv, {
     alias: { help: "h" },
@@ -531,6 +532,11 @@ app.on("ready", async () => {
     global.appLocalization = new AppLocalization({
         store: global.store,
         components: [(): void => tray.initApplicationMenu(), (): void => Menu.setApplicationMenu(buildMenuTemplate())],
+    });
+
+    session.defaultSession.setDisplayMediaRequestHandler((_, callback) => {
+        global.mainWindow?.webContents.send("openDesktopCapturerSourcePicker");
+        setDisplayMediaCallback(callback);
     });
 });
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -22,6 +22,7 @@ import { recordSSOSession } from "./protocol";
 import { randomArray } from "./utils";
 import { Settings } from "./settings";
 import { keytar } from "./keytar";
+import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback";
 
 ipcMain.on("setBadgeCount", function (_ev: IpcMainEvent, count: number): void {
     if (process.platform !== "win32") {
@@ -185,6 +186,11 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
                 name: source.name,
                 thumbnailURL: source.thumbnail.toDataURL(),
             }));
+            break;
+        case "callDisplayMediaCallback":
+            await getDisplayMediaCallback()?.({ video: args[0] });
+            setDisplayMediaCallback(null);
+            ret = null;
             break;
 
         case "clearStorage":

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -34,6 +34,7 @@ const CHANNELS = [
     "update-downloaded",
     "userDownloadCompleted",
     "userDownloadAction",
+    "openDesktopCapturerSourcePicker",
 ];
 
 contextBridge.exposeInMainWorld("electron", {


### PR DESCRIPTION
See https://github.com/electron/electron/pull/30702 - this has the benefit of the js-sdk and LiveKit not having to add custom logic for Electron

Fixes https://github.com/vector-im/element-call/issues/1242

Requires https://github.com/vector-im/element-web/pull/25802
Requires https://github.com/matrix-org/matrix-react-sdk/pull/11266

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->