### PR TITLE
Switch to hidden titleBar on macOS to integrate the app better

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -485,6 +485,11 @@ app.on("ready", async () => {
                 .mx_UserMenu {
                     margin-top: 28px !important;
                 }
+                /* Maintain alignment of the toggle space panel button */
+                .mx_SpacePanel_toggleCollapse {
+                    /* 19px original top value, 28px margin-top above, 12px original margin-top value */
+                    top: calc(19px + 28px - 12px) !important;
+                }
             `);
         }
 

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -454,6 +454,8 @@ app.on("ready", async () => {
         // https://www.electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
         backgroundColor: "#fff",
 
+        titleBarStyle: process.platform === "darwin" ? "hidden" : "default",
+
         icon: global.trayConfig.icon_path,
         show: false,
         autoHideMenuBar: global.store.get("autoHideMenuBar", true),
@@ -471,6 +473,79 @@ app.on("ready", async () => {
         },
     });
     global.mainWindow.loadURL("vector://vector/webapp/");
+
+    if (process.platform === "darwin") {
+        global.mainWindow.webContents.on("did-finish-load", () => {
+            global.mainWindow?.webContents.insertCSS(`
+                /* Create margin of space for the traffic light buttons */
+                .mx_UserMenu {
+                    margin-top: 28px !important;
+                }
+                
+                /* Mark the splash screen as a drag handle */
+                .mx_MatrixChat_splash {
+                    -webkit-app-region: drag;
+                }
+                /* Exclude the splash buttons from being drag handles */
+                .mx_MatrixChat_splashButtons {
+                    -webkit-app-region: no-drag;
+                }
+                
+                /* Mark the background as a drag handle */
+                .mx_AuthPage {
+                    -webkit-app-region: drag;
+                }
+                /* Exclude the main content elements from being drag handles */
+                .mx_AuthPage .mx_AuthPage_modalBlur,
+                .mx_AuthPage .mx_AuthFooter > * {
+                    -webkit-app-region: no-drag;
+                }
+                
+                /* Mark the header as a drag handle */
+                .mx_LeftPanel .mx_LeftPanel_filterContainer {
+                    -webkit-app-region: drag;
+                }
+                /* Exclude header interactive elements from being drag handles */
+                .mx_LeftPanel .mx_LeftPanel_filterContainer .mx_AccessibleButton {
+                    -webkit-app-region: no-drag;
+                }
+            
+                /* Mark the home page background as a drag handle */
+                .mx_HomePage {
+                    -webkit-app-region: drag;
+                }
+                /* Exclude interactive elements from being drag handles */
+                .mx_HomePage .mx_HomePage_body,
+                .mx_HomePage .mx_HomePage_default_wrapper > * {
+                    -webkit-app-region: no-drag;
+                }
+                
+                /* Mark the header as a drag handle */
+                .mx_RoomHeader {
+                    -webkit-app-region: drag;
+                    -webkit-user-select: none;
+                }
+                /* Exclude header interactive elements from being drag handles */
+                .mx_RoomHeader .mx_RoomHeader_avatar,
+                .mx_RoomHeader .mx_E2EIcon,
+                .mx_RoomHeader .mx_AccessibleButton {
+                    -webkit-app-region: no-drag;
+                }
+                
+                /* Mark the background as a drag handle */
+                .mx_RoomView_wrapper {
+                    -webkit-app-region: drag;
+                }
+                /* Exclude content elements from being drag handles */
+                .mx_SpaceRoomView_landing > *,
+                .mx_RoomPreviewBar,
+                .mx_RoomView_body,
+                .mx_RoomPreviewCard {
+                    -webkit-app-region: no-drag;
+                }
+            `);
+        });
+    }
 
     // Handle spellchecker
     // For some reason spellCheckerEnabled isn't persisted, so we have to use the store here

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -455,6 +455,7 @@ app.on("ready", async () => {
         backgroundColor: "#fff",
 
         titleBarStyle: process.platform === "darwin" ? "hidden" : "default",
+        trafficLightPosition: { x: 9, y: 8 },
 
         icon: global.trayConfig.icon_path,
         show: false,

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -40,6 +40,7 @@ import * as updater from "./updater";
 import { getProfileFromDeeplink, protocolInit } from "./protocol";
 import { _t, AppLocalization } from "./language-helper";
 import { setDisplayMediaCallback } from "./displayMediaCallback";
+import { setupMacosTitleBar } from "./macos-titlebar";
 
 const argv = minimist(process.argv, {
     alias: { help: "h" },
@@ -476,100 +477,7 @@ app.on("ready", async () => {
     global.mainWindow.loadURL("vector://vector/webapp/");
 
     if (process.platform === "darwin") {
-        let userMenuCssKey: string | undefined;
-
-        // eslint-disable-next-line no-inner-declarations
-        async function makeSpaceForTrafficLight(): Promise<void> {
-            userMenuCssKey = await global.mainWindow?.webContents.insertCSS(`
-                /* Create margin of space for the traffic light buttons */
-                .mx_UserMenu {
-                    margin-top: 28px !important;
-                }
-                /* Maintain alignment of the toggle space panel button */
-                .mx_SpacePanel_toggleCollapse {
-                    /* 19px original top value, 28px margin-top above, 12px original margin-top value */
-                    top: calc(19px + 28px - 12px) !important;
-                }
-            `);
-        }
-
-        global.mainWindow.on("enter-full-screen", () => {
-            if (userMenuCssKey !== undefined) {
-                global.mainWindow?.webContents.removeInsertedCSS(userMenuCssKey);
-            }
-        });
-        global.mainWindow.on("leave-full-screen", () => {
-            makeSpaceForTrafficLight();
-        });
-
-        global.mainWindow.webContents.on("did-finish-load", () => {
-            if (!global.mainWindow?.isFullScreen()) {
-                makeSpaceForTrafficLight();
-            }
-            global.mainWindow?.webContents.insertCSS(`
-                /* Mark the splash screen as a drag handle */
-                .mx_MatrixChat_splash {
-                    -webkit-app-region: drag;
-                }
-                /* Exclude the splash buttons from being drag handles */
-                .mx_MatrixChat_splashButtons {
-                    -webkit-app-region: no-drag;
-                }
-                
-                /* Mark the background as a drag handle */
-                .mx_AuthPage {
-                    -webkit-app-region: drag;
-                }
-                /* Exclude the main content elements from being drag handles */
-                .mx_AuthPage .mx_AuthPage_modalBlur,
-                .mx_AuthPage .mx_AuthFooter > * {
-                    -webkit-app-region: no-drag;
-                }
-                
-                /* Mark the header as a drag handle */
-                .mx_LeftPanel .mx_LeftPanel_filterContainer {
-                    -webkit-app-region: drag;
-                }
-                /* Exclude header interactive elements from being drag handles */
-                .mx_LeftPanel .mx_LeftPanel_filterContainer .mx_AccessibleButton {
-                    -webkit-app-region: no-drag;
-                }
-            
-                /* Mark the home page background as a drag handle */
-                .mx_HomePage {
-                    -webkit-app-region: drag;
-                }
-                /* Exclude interactive elements from being drag handles */
-                .mx_HomePage .mx_HomePage_body,
-                .mx_HomePage .mx_HomePage_default_wrapper > * {
-                    -webkit-app-region: no-drag;
-                }
-                
-                /* Mark the header as a drag handle */
-                .mx_RoomHeader {
-                    -webkit-app-region: drag;
-                    -webkit-user-select: none;
-                }
-                /* Exclude header interactive elements from being drag handles */
-                .mx_RoomHeader .mx_RoomHeader_avatar,
-                .mx_RoomHeader .mx_E2EIcon,
-                .mx_RoomHeader .mx_AccessibleButton {
-                    -webkit-app-region: no-drag;
-                }
-                
-                /* Mark the background as a drag handle */
-                .mx_RoomView_wrapper {
-                    -webkit-app-region: drag;
-                }
-                /* Exclude content elements from being drag handles */
-                .mx_SpaceRoomView_landing > *,
-                .mx_RoomPreviewBar,
-                .mx_RoomView_body,
-                .mx_RoomPreviewCard {
-                    -webkit-app-region: no-drag;
-                }
-            `);
-        });
+        setupMacosTitleBar(global.mainWindow);
     }
 
     // Handle spellchecker

--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -1,0 +1,115 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { BrowserWindow } from "electron";
+
+export function setupMacosTitleBar(window: BrowserWindow): void {
+    if (process.platform !== "darwin") return;
+
+    let userMenuCssKey: string | undefined;
+
+    async function makeSpaceForTrafficLight(): Promise<void> {
+        userMenuCssKey = await window.webContents.insertCSS(`
+            /* Create margin of space for the traffic light buttons */
+            .mx_UserMenu {
+                margin-top: 28px !important;
+            }
+            /* Maintain alignment of the toggle space panel button */
+            .mx_SpacePanel_toggleCollapse {
+                /* 19px original top value, 28px margin-top above, 12px original margin-top value */
+                top: calc(19px + 28px - 12px) !important;
+            }
+        `);
+    }
+
+    window.on("enter-full-screen", () => {
+        if (userMenuCssKey !== undefined) {
+            window.webContents.removeInsertedCSS(userMenuCssKey);
+        }
+    });
+    window.on("leave-full-screen", () => {
+        makeSpaceForTrafficLight();
+    });
+
+    window.webContents.on("did-finish-load", () => {
+        if (!window.isFullScreen()) {
+            makeSpaceForTrafficLight();
+        }
+        window.webContents.insertCSS(`
+            /* Mark the splash screen as a drag handle */
+            .mx_MatrixChat_splash {
+                -webkit-app-region: drag;
+            }
+            /* Exclude the splash buttons from being drag handles */
+            .mx_MatrixChat_splashButtons {
+                -webkit-app-region: no-drag;
+            }
+            
+            /* Mark the background as a drag handle */
+            .mx_AuthPage {
+                -webkit-app-region: drag;
+            }
+            /* Exclude the main content elements from being drag handles */
+            .mx_AuthPage .mx_AuthPage_modalBlur,
+            .mx_AuthPage .mx_AuthFooter > * {
+                -webkit-app-region: no-drag;
+            }
+            
+            /* Mark the header as a drag handle */
+            .mx_LeftPanel .mx_LeftPanel_filterContainer {
+                -webkit-app-region: drag;
+            }
+            /* Exclude header interactive elements from being drag handles */
+            .mx_LeftPanel .mx_LeftPanel_filterContainer .mx_AccessibleButton {
+                -webkit-app-region: no-drag;
+            }
+        
+            /* Mark the home page background as a drag handle */
+            .mx_HomePage {
+                -webkit-app-region: drag;
+            }
+            /* Exclude interactive elements from being drag handles */
+            .mx_HomePage .mx_HomePage_body,
+            .mx_HomePage .mx_HomePage_default_wrapper > * {
+                -webkit-app-region: no-drag;
+            }
+            
+            /* Mark the header as a drag handle */
+            .mx_RoomHeader {
+                -webkit-app-region: drag;
+                -webkit-user-select: none;
+            }
+            /* Exclude header interactive elements from being drag handles */
+            .mx_RoomHeader .mx_RoomHeader_avatar,
+            .mx_RoomHeader .mx_E2EIcon,
+            .mx_RoomHeader .mx_AccessibleButton {
+                -webkit-app-region: no-drag;
+            }
+            
+            /* Mark the background as a drag handle */
+            .mx_RoomView_wrapper {
+                -webkit-app-region: drag;
+            }
+            /* Exclude content elements from being drag handles */
+            .mx_SpaceRoomView_landing > *,
+            .mx_RoomPreviewBar,
+            .mx_RoomView_body,
+            .mx_RoomPreviewCard {
+                -webkit-app-region: no-drag;
+            }
+        `);
+    });
+}

--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -25,12 +25,12 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
         userMenuCssKey = await window.webContents.insertCSS(`
             /* Create margin of space for the traffic light buttons */
             .mx_UserMenu {
-                margin-top: 28px !important;
+                margin-top: 32px !important;
             }
             /* Maintain alignment of the toggle space panel button */
             .mx_SpacePanel_toggleCollapse {
-                /* 19px original top value, 28px margin-top above, 12px original margin-top value */
-                top: calc(19px + 28px - 12px) !important;
+                /* 19px original top value, 32px margin-top above, 12px original margin-top value */
+                top: calc(19px + 32px - 12px) !important;
             }
         `);
     }


### PR DESCRIPTION
<img width="1048" alt="image" src="https://github.com/vector-im/element-desktop/assets/2403652/566f95ff-a3d9-45ee-83f2-53128e64eb4a">

1 known medium issue:
+ with a modal open, the thing behind the modal still determines draggability - I think we could resolve that by adding a fake top bar matching the height of the traffic light area for modals and remove all other style overrides when a modal opens in favour of that one.

1 known minor issues:
+ on views without a distinct header element (home, space home, loading splash, login) the whole background is the drag element, this works but is just a bit unexpected

Worst case this may get moved behind a pref/lab if we consider it to not work well before the next RC


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Switch to hidden titleBar on macOS to integrate the app better ([\#1101](https://github.com/vector-im/element-desktop/pull/1101)).<!-- CHANGELOG_PREVIEW_END -->