### PR TITLE
Restore macOs room header dragability

### DIFF
--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -72,15 +72,17 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
             }
             
             /* Mark the header as a drag handle */
+            .mx_LegacyRoomHeader,
             .mx_RoomHeader {
                 -webkit-app-region: drag;
                 -webkit-user-select: none;
             }
             /* Exclude header interactive elements from being drag handles */
-            .mx_RoomHeader .mx_RoomHeader_avatar,
-            .mx_RoomHeader .mx_E2EIcon,
-            .mx_RoomHeader .mx_RoomTopic,
-            .mx_RoomHeader .mx_AccessibleButton {
+            .mx_RoomHeader .mx_DecoratedRoomAvatar,
+            .mx_LegacyRoomHeader .mx_LegacyRoomHeader_avatar,
+            .mx_LegacyRoomHeader .mx_E2EIcon,
+            .mx_LegacyRoomHeader .mx_RoomTopic,
+            .mx_LegacyRoomHeader .mx_AccessibleButton {
                 -webkit-app-region: no-drag;
             }
             

--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -79,6 +79,7 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
             }
             /* Exclude header interactive elements from being drag handles */
             .mx_RoomHeader .mx_DecoratedRoomAvatar,
+            .mx_RoomHeader_name,
             .mx_LegacyRoomHeader .mx_LegacyRoomHeader_avatar,
             .mx_LegacyRoomHeader .mx_E2EIcon,
             .mx_LegacyRoomHeader .mx_RoomTopic,


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-desktop/issues/1135

## Checklist

-   [ ] Ensure your code works with manual testing
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Restore macOs room header dragability ([\#1136](https://github.com/vector-im/element-desktop/pull/1136)). Fixes #1135.<!-- CHANGELOG_PREVIEW_END -->