### PR TITLE
Improve selectors for macos app draggable regions

### DIFF
--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -81,18 +81,24 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
                 -webkit-app-region: drag;
                 -webkit-user-select: none;
             }
+            .mx_ImageView_panel {
+                -webkit-app-region: drag;
+            }
             /* Exclude header interactive elements from being drag handles */
             .mx_RoomHeader .mx_DecoratedRoomAvatar,
             .mx_RoomHeader_name,
             .mx_LegacyRoomHeader .mx_LegacyRoomHeader_avatar,
             .mx_LegacyRoomHeader .mx_E2EIcon,
             .mx_LegacyRoomHeader .mx_RoomTopic,
-            .mx_LegacyRoomHeader .mx_AccessibleButton {
+            .mx_LegacyRoomHeader .mx_AccessibleButton,
+            .mx_ImageView_panel > .mx_ImageView_info_wrapper,
+            .mx_ImageView_panel > .mx_ImageView_title,
+            .mx_ImageView_panel > .mx_ImageView_toolbar > * {
                 -webkit-app-region: no-drag;
             }
             
-            /* Mark the background as a drag handle */
-            .mx_RoomView_wrapper {
+            /* Mark the background as a drag handle only if no modal is open */
+            .mx_MatrixChat_wrapper[aria-hidden="false"] .mx_RoomView_wrapper {
                 -webkit-app-region: drag;
             }
             /* Exclude content elements from being drag handles */


### PR DESCRIPTION
Disable background drag handles when modals are open as they interfere through the modal body

Fixes https://github.com/vector-im/element-desktop/issues/1169


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Improve selectors for macos app draggable regions ([\#1170](https://github.com/vector-im/element-desktop/pull/1170)). Fixes #1169.<!-- CHANGELOG_PREVIEW_END -->