### PR TITLE
Don't intercept Ctrl + Cmd + Q on macOS

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -260,7 +260,7 @@ global.appQuitting = false;
 const exitShortcuts: Array<(input: Input, platform: string) => boolean> = [
     (input, platform): boolean => platform !== "darwin" && input.alt && input.key.toUpperCase() === "F4",
     (input, platform): boolean => platform !== "darwin" && input.control && input.key.toUpperCase() === "Q",
-    (input, platform): boolean => platform === "darwin" && input.meta && input.key.toUpperCase() === "Q",
+    (input, platform): boolean => platform === "darwin" && input.meta && !input.control && input.key.toUpperCase() === "Q",
 ];
 
 const warnBeforeExit = (event: Event, input: Input): void => {


### PR DESCRIPTION
It's the [Lock Screen shortcut](https://support.apple.com/en-us/HT201236#sleep) since macOS High Sierra (10.13).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Ensure your code works with manual testing
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't intercept Ctrl + Cmd + Q on macOS ([\#1174](https://github.com/vector-im/element-desktop/pull/1174)). Contributed by @zhaofengli.<!-- CHANGELOG_PREVIEW_END -->