### PR TITLE
Turn off new room header by default

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -50,8 +50,7 @@
     "privacy_policy_url": "https://element.io/cookie-policy",
     "features": {
         "feature_spotlight": true,
-        "feature_video_rooms": true,
-        "feature_new_room_decoration_ui": true
+        "feature_video_rooms": true
     },
     "element_call": {
         "url": "https://element-call-livekit.netlify.app"


### PR DESCRIPTION
Early feedback indicates that the defaulting happened prematurely.

This undoes https://github.com/vector-im/element-desktop/pull/1194.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->