### PR TITLE
Bump matrix-web-i18n to 3.1.3 for KEY_SEPARATOR

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "fs-extra": "^11.0.0",
         "glob": "^10.0.0",
         "jest": "^29.0.0",
-        "matrix-web-i18n": "^3.1.1",
+        "matrix-web-i18n": "^3.1.3",
         "mkdirp": "^3.0.0",
         "node-pre-gyp": "^0.17.0",
         "pacote": "^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5657,10 +5657,10 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
-matrix-web-i18n@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/matrix-web-i18n/-/matrix-web-i18n-3.1.1.tgz#da851748515b20ca15fa986817bbce2e242b3dd6"
-  integrity sha512-BOeOTedtONIqVQUlyHFXpxXkrETWdCoJdToyA+edMU+yGjKOW7bekAd9uAEfkV9jErP5eXw3cHYsKZPpa8ifWg==
+matrix-web-i18n@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/matrix-web-i18n/-/matrix-web-i18n-3.1.3.tgz#b462015b138ebdd288ed945507abea42c896f52d"
+  integrity sha512-9JUUTifqS/Xe6YQr5uDbX04xvr5Pxg8aU7tRKx49/ZLqm4dZoJKo4SKpyLEwCQeNjAvjcKuXibWO+2hkZ2/Ojw==
   dependencies:
     "@babel/parser" "^7.18.5"
     "@babel/traverse" "^7.18.5"


### PR DESCRIPTION
Similar to https://github.com/vector-im/element-web/pull/26287

Translations were missing when we deployed today's release to staging, and we think this was why. The running cod didn't have a key separator set in counterpart.