### PR TITLE
Implement macos title bar negative space

### DIFF
--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -65,15 +65,6 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
             .mx_AuthPage .mx_AuthFooter > * {
                 -webkit-app-region: no-drag;
             }
-            
-            /* Mark the header as a drag handle */
-            .mx_LeftPanel .mx_LeftPanel_filterContainer {
-                -webkit-app-region: drag;
-            }
-            /* Exclude header interactive elements from being drag handles */
-            .mx_LeftPanel .mx_LeftPanel_filterContainer .mx_AccessibleButton {
-                -webkit-app-region: no-drag;
-            }
         
             /* Mark the home page background as a drag handle */
             .mx_HomePage {
@@ -86,23 +77,10 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
             }
             
             /* Mark the header as a drag handle */
-            .mx_LegacyRoomHeader,
-            .mx_RoomHeader {
-                -webkit-app-region: drag;
-                -webkit-user-select: none;
-            }
             .mx_ImageView_panel {
                 -webkit-app-region: drag;
             }
             /* Exclude header interactive elements from being drag handles */
-            .mx_RoomHeader .mx_BaseAvatar,
-            .mx_RoomHeader_heading,
-            .mx_RoomHeader button,
-            .mx_RoomHeader .mx_FacePile,
-            .mx_LegacyRoomHeader .mx_LegacyRoomHeader_avatar,
-            .mx_LegacyRoomHeader .mx_E2EIcon,
-            .mx_LegacyRoomHeader .mx_RoomTopic,
-            .mx_LegacyRoomHeader .mx_AccessibleButton,
             .mx_ImageView_panel > .mx_ImageView_info_wrapper,
             .mx_ImageView_panel > .mx_ImageView_title,
             .mx_ImageView_panel > .mx_ImageView_toolbar > * {
@@ -119,7 +97,9 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
             .mx_RoomView_body,
             .mx_AutoHideScrollbar,
             .mx_RightPanel_ResizeWrapper,
-            .mx_RoomPreviewCard {
+            .mx_RoomPreviewCard,
+            .mx_LeftPanel,
+            .mx_RoomView {
                 -webkit-app-region: no-drag;
             }
             /* Exclude context menus and their backgrounds */
@@ -130,6 +110,32 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
             iframe {
                 -webkit-app-region: no-drag;
             }
+
+            /* Add a bar above room header + left panel */
+            
+            .mx_LeftPanel {
+                flex-direction: column;
+            }
+
+            .mx_LeftPanel::before {
+                content: "";
+                height: 25px;
+                -webkit-app-region: drag;
+            }
+
+            .mx_RoomView::before {
+                content: "";
+                -webkit-app-region: drag;
+            }
+
+            .mx_RoomView[data-room-header="new"]::before {
+                height: 13px;
+            }
+
+            .mx_RoomView[data-room-header="legacy"]::before {
+                height: 27px;
+            }
+
         `);
     }
 

--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -119,7 +119,7 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
 
             .mx_LeftPanel::before {
                 content: "";
-                height: 25px;
+                height: 20px;
                 -webkit-app-region: drag;
             }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-desktop/issues/1245
Needs https://github.com/matrix-org/matrix-react-sdk/pull/11735 to land before this pull request

<img width="1258" alt="Screenshot 2023-10-11 at 11 11 31" src="https://github.com/vector-im/element-desktop/assets/769871/435831c9-8b85-4972-a219-8002f10f5b28">
<img width="1440" alt="Screenshot 2023-10-11 at 17 55 01" src="https://github.com/vector-im/element-desktop/assets/769871/7328eb36-2974-478d-b06a-1ed71e422e86">

All the `drag` regions do not delegate the hover state to the web page. Which means the new room header would only trigger its hover state for `no-drag` zones. This does not allow us to implement the experience that we wish to provide.

We have decide to implement this compromise that adds negative space at the top of the application where you can drag the window around. This is a compromise and a step in the right direction until we have enough time to redesign the top bar and implement something more constructive rather than empty space.

## Checklist

-   [x] Ensure your code works with manual testing
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Implement macos title bar negative space ([\#1272](https://github.com/vector-im/element-desktop/pull/1272)). Fixes #1245.<!-- CHANGELOG_PREVIEW_END -->