### PR TITLE
Allow overwriting app.element.io when popping out widgets

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,3 +10,7 @@
 # Distribution
 
 -   [Updates](updates.md)
+
+# Setup
+
+-   [Config](config.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,15 @@
+# Configuration
+
+All Element Web options documented [here](https://github.com/vector-im/element-web/blob/develop/docs/config.md) can be used as well as the following:
+
+---
+
+The app contains a configuration file specified at build time using [these instructions](https://github.com/vector-im/element-desktop/#config).
+This config can be overwritten by the end using by creating a `config.json` file at the paths described [here](https://github.com/vector-im/element-desktop/#user-specified-configjson).
+
+After changing the config, the app will need to be exited fully (including via the task tray) and re-started.
+
+---
+
+1. `update_base_url`: Specifies the URL of the update server, see [document](https://github.com/vector-im/element-desktop/blob/develop/docs/updates.md).
+2. `web_base_url`: Specifies the Element Web URL when performing actions such as popout widget. Defaults to `https://app.element.io/`.

--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -85,8 +85,9 @@ function onLinkContextMenu(ev: Event, params: ContextMenuParams, webContents: We
     if (url.startsWith("vector://vector/webapp")) {
         // Avoid showing a context menu for app icons
         if (params.hasImageContents) return;
-        // Rewrite URL so that it can be used outside of the app
-        url = "https://app.element.io/" + url.substring(23);
+        const baseUrl = vectorConfig.web_base_url ?? "https://app.element.io/";
+        // Rewrite URL so that it can be used outside the app
+        url = baseUrl + url.substring(23);
     }
 
     const popupMenu = new Menu();


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-desktop/issues/1187

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow overwriting app.element.io when popping out widgets ([\#1277](https://github.com/vector-im/element-desktop/pull/1277)). Fixes #1187.<!-- CHANGELOG_PREVIEW_END -->