### PR TITLE
Workaround for macos-latest switching to Python 3.12

### DIFF
--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -67,7 +67,10 @@ jobs:
 
             - name: Build Natives
               if: steps.cache.outputs.cache-hit != 'true'
-              run: "yarn build:native:universal"
+              run: |
+                  # Python 3.12 drops distutils which keytar relies on
+                  pip3 install setuptools
+                  yarn build:native:universal
 
             - name: "[Nightly] Resolve version"
               id: nightly


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->